### PR TITLE
ONNX runtime node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "lodash": "4.17.21",
         "minimist": "1.2.8",
         "node-osc": "9.1.0",
+        "onnxruntime-web": "^1.19.0",
         "react": "18.2.0",
         "react-color": "2.19.3",
         "react-dom": "18.2.0",
@@ -1660,6 +1661,60 @@
         "node": ">=14"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "25.0.7",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.7.tgz",
@@ -2937,9 +2992,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001589",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001589.tgz",
-      "integrity": "sha512-vNQWS6kI+q6sBlHbh71IIeC+sRwK2N3EDySc/updIGhIee2x5z00J4c1242/5/d6EpEMdOnk/m+6tuk4/tcsqg==",
+      "version": "1.0.30001653",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001653.tgz",
+      "integrity": "sha512-XGWQVB8wFQ2+9NZwZ10GxTYC5hk0Fa+q8cSkr0tgvMhYhMHP/QC+WTgrePMDBWiWc/pV+1ik82Al20XOK25Gcw==",
       "dev": true,
       "funding": [
         {
@@ -4304,6 +4359,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
+      "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ=="
+    },
     "node_modules/foreground-child": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
@@ -4593,6 +4653,11 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -5484,6 +5549,29 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onnxruntime-common": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.19.0.tgz",
+      "integrity": "sha512-Oo16UIJ/xLOtZDVGcL4bL8EP8MiNFztyBmR3pB14D+cl/UCpOgHHzEk0MADSmYXQ0FgyEegPXtOFcJqhq1YRsw=="
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.19.0.tgz",
+      "integrity": "sha512-EY2KjvfJ/f5nxiXDii4eD0xe5KIn+mRs55F6z2qomALyG05Qj+kqF81CKqzTa4cXowE9b9aVSqsvEVZkjOI5yA==",
+      "dependencies": {
+        "flatbuffers": "^1.12.0",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.19.0",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
     "node_modules/osc-min": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/osc-min/-/osc-min-1.1.2.tgz",
@@ -5582,6 +5670,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
     "node_modules/plist": {
       "version": "3.1.0",
@@ -5780,6 +5873,34 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/protobufjs/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/pump": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lodash": "4.17.21",
     "minimist": "1.2.8",
     "node-osc": "9.1.0",
+    "onnxruntime-web": "^1.19.0",
     "react": "18.2.0",
     "react-color": "2.19.3",
     "react-dom": "18.2.0",
@@ -54,7 +55,11 @@
   "build": {
     "appId": "be.debleser.figment",
     "productName": "Figment",
-    "files": ["build/**/*", "examples/**/*", "src/electron/**/*"],
+    "files": [
+      "build/**/*",
+      "examples/**/*",
+      "src/electron/**/*"
+    ],
     "directories": {
       "buildResources": "res"
     },

--- a/src/model/Library.js
+++ b/src/model/Library.js
@@ -121,6 +121,7 @@ export default class Library {
     this.nodeTypes.push({ name: 'Segment Pose', type: 'ml.segmentPose', source: ml.segmentPose });
     this.nodeTypes.push({ name: 'Detect Hands', type: 'ml.detectHands', source: ml.detectHands });
     this.nodeTypes.push({ name: 'Image to Image Model', type: 'ml.imageToImageModel', source: ml.imageToImageModel });
+    this.nodeTypes.push({ name: 'ONNX Image Model', type: 'ml.onnxImageModel', source: ml.onnxImageModel });
 
     // this.nodeTypes.push({ name: 'Segment Pose 2', type: 'ml.segmentPose2', source: ml.segmentPose2 });
     // this.nodeTypes.push({ name: 'Classify Image', type: 'ml.classifyImage', source: ml.classifyImage });

--- a/src/model/Library.js
+++ b/src/model/Library.js
@@ -109,7 +109,6 @@ export default class Library {
     this.nodeTypes.push({ name: 'Threshold', type: 'image.threshold', source: image.threshold });
     this.nodeTypes.push({ name: 'Trail', type: 'image.trail', source: image.trail });
     this.nodeTypes.push({ name: 'Transform', type: 'image.transform', source: image.transform });
-    this.nodeTypes.push({ name: 'Unsplash Image', type: 'image.unsplash', source: image.unsplash });
     this.nodeTypes.push({ name: 'Vignette', type: 'image.vignette', source: image.vignette });
     this.nodeTypes.push({ name: 'Wrap', type: 'image.wrap', source: image.wrap });
     this.nodeTypes.push({ name: 'Webcam Image', type: 'image.webcamImage', source: image.webcamImage });

--- a/src/model/sources.js
+++ b/src/model/sources.js
@@ -4893,9 +4893,12 @@ ml.onnxImageModel = `// Run a generative image to image model using ONNX Runtime
 const imageIn = node.imageIn('in');
 const modelFileIn = node.fileIn('model');
 const imageOut = node.imageOut('out');
-let oldModelFile, session, canvas, framebuffer, isRunning = false;
-let inputBuffer = new Float32Array(3 * 512 * 512);
-let outputBuffer = new Uint8Array(4 * 512 * 512);
+let oldModelFile, session, device, canvas, framebuffer, isRunning = false;
+const BUFFER_SIZE = 3 * 512 * 512 * 4;
+const inputArray = new Float32Array(3 * 512 * 512);
+const outputArray = new Float32Array(3 * 512 * 512);
+const textureBuffer = new Uint8Array(4 * 512 * 512);
+let inputBuffer, outputBuffer, stagingBuffer, inputTensor, outputTensor;
 
 node.onStart = async () => {
   canvas = new OffscreenCanvas(512, 512);
@@ -4906,7 +4909,13 @@ async function loadModel() {
   if (!modelFileIn.value) return;
   const modelUrl = figment.urlForAsset(modelFileIn.value);
   try {
-    session = await ort.InferenceSession.create(modelUrl, {  executionProviders: ['webgpu'] });
+    session = await ort.InferenceSession.create(modelUrl, { executionProviders: ['webgpu'], enableGraphCapture: true });
+    device = ort.env.webgpu.device;
+    inputBuffer = device.createBuffer({ usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST, size: BUFFER_SIZE });
+    outputBuffer = device.createBuffer({ usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC, size: BUFFER_SIZE });
+    stagingBuffer = device.createBuffer({ usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST, size: BUFFER_SIZE });
+    inputTensor = ort.Tensor.fromGpuBuffer(inputBuffer, { dataType: "float32", dims: [1, 3, 512, 512] });
+    outputTensor = ort.Tensor.fromGpuBuffer(outputBuffer, { dataType: "float32", dims: [1, 3, 512, 512] });
     oldModelFile = modelFileIn.value;
   } catch (e) {
     console.error("Failed to load ONNX model:", e);
@@ -4939,30 +4948,39 @@ node.onRender = async () => {
   let blueOffset = pixelCount * 2;
   for (let i = 0; i < pixelCount; i++) {
     const inOffset = i * 4;
-    inputBuffer[redOffset++] = imageData.data[inOffset] / 127.5 - 1;
-    inputBuffer[greenOffset++] = imageData.data[inOffset + 1] / 127.5 - 1;
-    inputBuffer[blueOffset++] = imageData.data[inOffset + 2] / 127.5 - 1;
+    inputArray[redOffset++] = imageData.data[inOffset] / 127.5 - 1;
+    inputArray[greenOffset++] = imageData.data[inOffset + 1] / 127.5 - 1;
+    inputArray[blueOffset++] = imageData.data[inOffset + 2] / 127.5 - 1;
   }
-  const inputTensor = new ort.Tensor('float32', inputBuffer, [1, 3, 512, 512]);
+  device.queue.writeBuffer(inputBuffer, 0, inputArray);
 
   // Run inference
-  const outputMap = await session.run({ 'input': inputTensor });
-  const outputData = outputMap['output'].data;
+  await session.run({ input: inputTensor }, { output: outputTensor });
 
-  // Convert output tensor to framebuffer
+  // Do some WebGPU magic to get the data from the output tensor to a Float32Array
+  const commandEncoder = device.createCommandEncoder();
+  commandEncoder.copyBufferToBuffer(outputBuffer, 0, stagingBuffer, 0, BUFFER_SIZE);
+  device.queue.submit([commandEncoder.finish()]);
+  await stagingBuffer.mapAsync(GPUMapMode.READ, 0, BUFFER_SIZE);
+  const copyArrayBuffer = stagingBuffer.getMappedRange(0, BUFFER_SIZE);
+  outputArray.set(new Float32Array(copyArrayBuffer));
+  stagingBuffer.unmap();
+
+  // Convert the output array to framebuffer
   redOffset = 0;
   greenOffset = pixelCount;
   blueOffset = pixelCount * 2;
   for (let i = 0; i < pixelCount; i++) {
     const outOffset = i * 4;
-    outputBuffer[outOffset] = clamp(outputData[redOffset++] * 127.5 + 127.5);
-    outputBuffer[outOffset + 1] = clamp(outputData[greenOffset++] * 127.5 + 127.5);
-    outputBuffer[outOffset + 2] = clamp(outputData[blueOffset++] * 127.5 + 127.5);
-    outputBuffer[outOffset + 3] = 255;
+    textureBuffer[outOffset] = clamp(outputArray[redOffset++] * 127.5 + 127.5);
+    textureBuffer[outOffset + 1] = clamp(outputArray[greenOffset++] * 127.5 + 127.5);
+    textureBuffer[outOffset + 2] = clamp(outputArray[blueOffset++] * 127.5 + 127.5);
+    textureBuffer[outOffset + 3] = 255;
   }
+
   // Upload the RGBA data directly to the framebuffer's texture
   gl.bindTexture(gl.TEXTURE_2D, framebuffer.texture);
-  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 512, 512, 0, gl.RGBA, gl.UNSIGNED_BYTE, outputBuffer);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 512, 512, 0, gl.RGBA, gl.UNSIGNED_BYTE, textureBuffer);
   gl.bindTexture(gl.TEXTURE_2D, null);
   imageOut.set(framebuffer);
   isRunning = false;

--- a/src/model/sources.js
+++ b/src/model/sources.js
@@ -4033,61 +4033,6 @@ node.onRender = () => {
 };
 `;
 
-image.unsplash = `// Fetch a random image from Unsplash.
-
-const fragmentShader = \`
-precision mediump float;
-uniform sampler2D u_image;
-varying vec2 v_uv;
-void main() {
-  gl_FragColor = texture2D(u_image, v_uv);
-}
-\`;
-
-const queryIn = node.stringIn('query', 'kitten');
-const widthIn = node.numberIn('width', 300);
-const heightIn = node.numberIn('height', 300);
-const imageOut = node.imageOut('image');
-
-let _texture, framebuffer, program, shouldLoad;
-
-node.onStart = () => {
-  program = figment.createShaderProgram(fragmentShader);
-  framebuffer = new figment.Framebuffer();
-  shouldLoad = true;
-}
-
-node.onRender = async () => {
-  if (!shouldLoad) return;
-  if (!queryIn.value || queryIn.value.trim().length === 0) return;
-  const url = \`https://source.unsplash.com/\${widthIn.value}x\${heightIn.value}?\${queryIn.value}\`;
-  try {
-    const { texture, image } = await figment.createTextureFromUrlAsync(url);
-    shouldLoad = false;
-    if (_texture) {
-      gl.deleteTexture(_texture);
-    }
-    _texture = texture;
-    framebuffer.setSize(image.naturalWidth, image.naturalHeight);
-    framebuffer.bind();
-    figment.clear();
-    figment.drawQuad(program, { u_image: texture });
-    framebuffer.unbind();
-    imageOut.set(framebuffer);
-  } catch (err) {
-    console.error(\`Image load error: \${err\}\`);
-  }
-}
-
-function setShouldLoad() {
-  shouldLoad = true;
-}
-
-queryIn.onChange = figment.debounce(setShouldLoad, 500);
-widthIn.onChange = setShouldLoad;
-heightIn.onChange = setShouldLoad;
-`;
-
 image.vignette = `// Vignette  on image.
 
 const fragmentShader = \`


### PR DESCRIPTION
This introduces [onnxruntime-web](https://onnxruntime.ai/docs/tutorials/web/build-web-app.html) to do inference with ONNX using WebGPU.

This node is as efficient as possible within the current framework. However, our WebGL frame buffers and WebGPU buffers don't directly talk to each other, which means we have to do a bunch of conversions and copying back and forth between GPU and CPU. We try to optimize this by reusing the buffers as much as we can.

<img width="553" alt="Screenshot 2024-08-27 at 22 53 05" src="https://github.com/user-attachments/assets/fc0aba55-dad3-4d2f-8fd2-4147d7269a39">
