### PR TITLE
Add error handling display for nodes

### DIFF
--- a/src/model/Network.js
+++ b/src/model/Network.js
@@ -342,8 +342,10 @@ export default class Network {
     if (node.onStart) {
       try {
         await node.onStart(node);
+        node.error = null;
       } catch (err) {
         console.error(err && err.stack);
+        node.error = err && err.message ? err.message : String(err);
         debugger;
       }
     }
@@ -354,8 +356,10 @@ export default class Network {
       // console.log(`render ${node.id} ${node.name}`);
       try {
         await node.onRender();
+        node.error = null;
       } catch (e) {
         console.error(e && e.stack);
+        node.error = e && e.message ? e.message : String(e);
       }
       // Set the value of the connected input ports to the output ports of this node.
       for (const conn of this.connections) {

--- a/src/model/Node.js
+++ b/src/model/Node.js
@@ -31,9 +31,11 @@ export default class Node {
     this.outPorts = [];
     this.isDirty = true;
     this._timeDependent = false;
+    this.error = null;
   }
 
   _markDirty() {
+    this.error = null;
     this.network.markNodeDirty(this);
   }
 

--- a/src/ui/NetworkEditor.jsx
+++ b/src/ui/NetworkEditor.jsx
@@ -502,12 +502,13 @@ export default class NetworkEditor extends Component {
       const [nodeX, nodeY] = this._coordsToView(node.x, node.y);
       const nodeWidth = NODE_WIDTH * this.state.scale;
       const nodeHeight = NODE_HEIGHT * this.state.scale;
-      if (selection.has(node)) {
-        ctx.fillStyle = COLORS.blue600;
-        // ctx.fillRect(node.x - 3, node.y - 3, nodeWidth + 6, NODE_HEIGHT + 6);
-      } else {
-        ctx.fillStyle = COLORS.gray700;
+      let borderColor = COLORS.gray700;
+      if (node.error) {
+        borderColor = COLORS.red500;
+      } else if (selection.has(node)) {
+        borderColor = COLORS.blue600;
       }
+      ctx.fillStyle = borderColor;
 
       ctx.fillRect(nodeX, nodeY, nodeWidth, NODE_BORDER);
       ctx.fillRect(nodeX, nodeY + nodeHeight - NODE_BORDER, nodeWidth, NODE_BORDER);

--- a/src/ui/ParamsEditor.jsx
+++ b/src/ui/ParamsEditor.jsx
@@ -519,6 +519,7 @@ export default class ParamsEditor extends Component {
           </span>
           <span className="text-gray-500 text-xs ml-3">{node.type}</span>
         </div>
+        {node.error && <div className="params__error">{node.error}</div>}
         <div className="params__grid grid ">{node.inPorts.map((port) => this._renderPort(network, node, port))}</div>
       </div>
     );

--- a/src/ui/css/main.css
+++ b/src/ui/css/main.css
@@ -223,6 +223,13 @@ main {
   align-items: baseline;
 }
 
+.params__error {
+  color: var(--red500);
+  padding: 0 1rem;
+  margin-bottom: 0.5rem;
+  font-size: 0.75rem;
+}
+
 .params__grid {
   display: grid;
   grid-template-columns: 96px 1fr 16px;


### PR DESCRIPTION
## Summary
- track errors on nodes
- draw error borders in NetworkEditor
- show error message in ParamsEditor
- style new error text

## Testing
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6852883da1308321ace088cd360b8523