### PR TITLE
Fix multi-node drag

### DIFF
--- a/src/ui/NetworkEditor.jsx
+++ b/src/ui/NetworkEditor.jsx
@@ -345,7 +345,9 @@ export default class NetworkEditor extends Component {
           this._dragMode = DRAG_MODE_IDLE;
         } else {
           this._dragMode = DRAG_MODE_DRAG_NODE;
-          this.props.onSelectNode(node);
+          if (!this.props.selection.has(node)) {
+            this.props.onSelectNode(node);
+          }
           this._draw();
         }
       }


### PR DESCRIPTION
## Summary
- keep existing selection when starting a drag on an already selected node

## Testing
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_68551ab85f248321900b936cbb602a9c