### PR TITLE
Implement sectionIn separator

### DIFF
--- a/src/model/Network.js
+++ b/src/model/Network.js
@@ -11,6 +11,7 @@ import Port, {
   PORT_TYPE_COLOR,
   PORT_TYPE_FILE,
   PORT_TYPE_DIRECTORY,
+  PORT_TYPE_SECTION,
   PORT_TYPE_IMAGE,
   PORT_TYPE_BOOLEAN,
   PORT_IN,
@@ -225,6 +226,8 @@ export default class Network {
             port._value = value;
           } else if (port.type === PORT_TYPE_DIRECTORY) {
             port._value = value;
+          } else if (port.type === PORT_TYPE_SECTION) {
+            // sections have no value
           } else {
             warnings.push(`Node ${node.name} (${node.id}) - port ${portName}: unsupported port type ${port.type} ${value}.`);
           }
@@ -276,7 +279,7 @@ export default class Network {
     for (const node of this.nodes) {
       const values = {};
       for (const port of node.inPorts) {
-        if (port.type === PORT_TYPE_IMAGE || port.type === PORT_TYPE_BOOLEAN) continue;
+        if (port.type === PORT_TYPE_IMAGE || port.type === PORT_TYPE_BOOLEAN || port.type === PORT_TYPE_SECTION) continue;
         if (this.isConnected(port)) continue;
         if (port._value.type === 'expression') {
           values[port.name] = structuredClone(port._value);
@@ -298,6 +301,8 @@ export default class Network {
             value = port.value;
           } else if (port.type === PORT_TYPE_DIRECTORY) {
             value = port.value;
+          } else if (port.type === PORT_TYPE_SECTION) {
+            continue;
           }
           values[port.name] = { type: 'value', value };
         }

--- a/src/model/Node.js
+++ b/src/model/Node.js
@@ -9,6 +9,7 @@ import Port, {
   PORT_TYPE_COLOR,
   PORT_TYPE_FILE,
   PORT_TYPE_DIRECTORY,
+  PORT_TYPE_SECTION,
   PORT_TYPE_IMAGE,
   PORT_TYPE_OBJECT,
   PORT_IN,
@@ -175,6 +176,14 @@ export default class Node {
       this.inPorts.push(inPort);
       return inPort;
     }
+  }
+
+  sectionIn(name = '') {
+    const portName = `__section_${this.inPorts.length}`;
+    const inPort = new Port(this, portName, PORT_TYPE_SECTION, PORT_IN);
+    inPort.label = name;
+    this.inPorts.push(inPort);
+    return inPort;
   }
 
   imageIn(name) {

--- a/src/model/Port.js
+++ b/src/model/Port.js
@@ -11,6 +11,7 @@ export const PORT_TYPE_COLOR = 'color';
 export const PORT_TYPE_POINT = 'point';
 export const PORT_TYPE_FILE = 'file';
 export const PORT_TYPE_DIRECTORY = 'directory';
+export const PORT_TYPE_SECTION = 'section';
 export const PORT_TYPE_IMAGE = 'image';
 export const PORT_TYPE_OBJECT = 'object';
 export const PORT_TYPE_BOOLEAN = 'boolean';

--- a/src/ui/ParamsEditor.jsx
+++ b/src/ui/ParamsEditor.jsx
@@ -19,6 +19,7 @@ import {
   PORT_TYPE_FILE,
   PORT_TYPE_DIRECTORY,
   PORT_TYPE_OBJECT,
+  PORT_TYPE_SECTION,
 } from '../model/Port';
 
 const NUMBER_DRAG_IDLE = 'idle';
@@ -671,6 +672,12 @@ export default class ParamsEditor extends Component {
       );
     } else if (port.type === PORT_TYPE_TRIGGER) {
       return;
+    } else if (port.type === PORT_TYPE_SECTION) {
+      return (
+        <div key={port.name} className="col-span-3 my-2">
+          {port.label ? <div className="uppercase text-gray-300 text-xs">{port.label}</div> : <hr className="border-gray-700" />}
+        </div>
+      );
     } else if (port.type === PORT_TYPE_BUTTON) {
       field = (
         <Fragment key={port.name}>


### PR DESCRIPTION
## Summary
- add new port type `section` for UI separators
- implement `node.sectionIn()` method
- ignore section ports in network serialization
- render section headings or dividers in ParamsEditor

## Testing
- `npm run format`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68571333b27c832199e35aff0cc3f945