### PR TITLE
Add undo/redo for all network-mutating actions

### DIFF
--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -453,7 +453,20 @@ function createApplicationMenu() {
     ],
   };
 
-  const template = [...(isMac ? [macAppMenu] : []), fileMenu, { role: 'editMenu' }, viewMenu, { role: 'windowMenu' }];
+  const editMenu = {
+    label: 'Edit',
+    submenu: [
+      { label: 'Undo', accelerator: 'CmdOrCtrl+Z', click: emit('undo') },
+      { label: 'Redo', accelerator: 'CmdOrCtrl+Shift+Z', click: emit('redo') },
+      { type: 'separator' },
+      { role: 'cut' },
+      { role: 'copy' },
+      { role: 'paste' },
+      { role: 'selectAll' },
+    ],
+  };
+
+  const template = [...(isMac ? [macAppMenu] : []), fileMenu, editMenu, viewMenu, { role: 'windowMenu' }];
   const menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);
 }

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -71,11 +71,27 @@ export default function App(props) {
     startNetwork();
   }, [startNetwork]);
 
+  const undo = useAppStore((state) => state.undo);
+  const redo = useAppStore((state) => state.redo);
+
   const onKeyDown = useCallback(
     (e) => {
       if (e.keyCode === 27 && useAppStore.getState().fullscreen) toggleFullscreen();
+      if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+      if ((e.ctrlKey || e.metaKey) && !e.shiftKey && e.key === 'z') {
+        e.preventDefault();
+        undo();
+      }
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'z') {
+        e.preventDefault();
+        redo();
+      }
+      if ((e.ctrlKey || e.metaKey) && e.key === 'y') {
+        e.preventDefault();
+        redo();
+      }
     },
-    [toggleFullscreen],
+    [toggleFullscreen, undo, redo],
   );
 
   // Wire listeners and RAF loop explicitly here

--- a/src/ui/NetworkEditor.jsx
+++ b/src/ui/NetworkEditor.jsx
@@ -358,6 +358,7 @@ export default function NetworkEditor({ offscreenCanvas }) {
           dragModeRef.current = DRAG_MODE_IDLE;
         } else {
           dragModeRef.current = DRAG_MODE_DRAG_NODE;
+          useAppStore.getState().pushSnapshot();
           const currentSelection = useAppStore.getState().selection;
           if (!currentSelection.has(node)) {
             selectNode(node);
@@ -438,6 +439,9 @@ export default function NetworkEditor({ offscreenCanvas }) {
         }
       }
       selectNodes(newSelection);
+    }
+    if (dragModeRef.current === DRAG_MODE_DRAG_NODE) {
+      useAppStore.getState().setDirty(true);
     }
     window.removeEventListener('mousemove', onMouseDrag);
     window.removeEventListener('mouseup', onMouseUp);

--- a/src/ui/store.js
+++ b/src/ui/store.js
@@ -6,6 +6,8 @@ import { upgradeProject } from '../file-format';
 import { PORT_TYPE_IMAGE } from '../model/Port';
 
 // Centralized app UI state using Zustand
+const HISTORY_LIMIT = 50;
+
 const initialLibrary = new Library();
 const initialNetwork = new Network(initialLibrary);
 initialNetwork.parse(getDefaultNetwork());
@@ -38,6 +40,9 @@ export const useAppStore = create((set, get) => ({
   midiMessageMap: new Map(),
   midiProgramChangeMap: new Map(),
   midiDevices: [],
+  undoStack: [],
+  redoStack: [],
+  _lastPortValueSnapshotTime: 0,
 
   // Generic setter helper
   set: (partial) => set(partial),
@@ -50,6 +55,82 @@ export const useAppStore = create((set, get) => ({
   setDirty(dirty) {
     window.desktop.setDocumentEdited(dirty);
     set({ dirty });
+  },
+
+  // Undo/Redo
+  pushSnapshot() {
+    const { network, selection, undoStack } = get();
+    const snapshot = {
+      network: network.serialize(),
+      selectedNodeIds: Array.from(selection).map((n) => n.id),
+    };
+    const newStack = [...undoStack, snapshot];
+    if (newStack.length > HISTORY_LIMIT) {
+      newStack.shift();
+    }
+    set({ undoStack: newStack, redoStack: [] });
+  },
+  async undo() {
+    const { undoStack, redoStack, network, selection, library } = get();
+    if (undoStack.length === 0) return;
+    const currentSnapshot = {
+      network: network.serialize(),
+      selectedNodeIds: Array.from(selection).map((n) => n.id),
+    };
+    const newRedoStack = [...redoStack, currentSnapshot];
+    const newUndoStack = [...undoStack];
+    const snapshot = newUndoStack.pop();
+    network.stop();
+    const newNetwork = new Network(library);
+    newNetwork.parse(snapshot.network);
+    await newNetwork.start();
+    newNetwork.doFrame();
+    const newSelection = new Set();
+    for (const id of snapshot.selectedNodeIds) {
+      const node = newNetwork.nodes.find((n) => n.id === id);
+      if (node) newSelection.add(node);
+    }
+    set({
+      network: newNetwork,
+      undoStack: newUndoStack,
+      redoStack: newRedoStack,
+      selection: newSelection,
+      tabs: [],
+      activeTabIndex: -1,
+    });
+    get().setDirty(true);
+    get().forceRedraw();
+  },
+  async redo() {
+    const { undoStack, redoStack, network, selection, library } = get();
+    if (redoStack.length === 0) return;
+    const currentSnapshot = {
+      network: network.serialize(),
+      selectedNodeIds: Array.from(selection).map((n) => n.id),
+    };
+    const newUndoStack = [...undoStack, currentSnapshot];
+    const newRedoStack = [...redoStack];
+    const snapshot = newRedoStack.pop();
+    network.stop();
+    const newNetwork = new Network(library);
+    newNetwork.parse(snapshot.network);
+    await newNetwork.start();
+    newNetwork.doFrame();
+    const newSelection = new Set();
+    for (const id of snapshot.selectedNodeIds) {
+      const node = newNetwork.nodes.find((n) => n.id === id);
+      if (node) newSelection.add(node);
+    }
+    set({
+      network: newNetwork,
+      undoStack: newUndoStack,
+      redoStack: newRedoStack,
+      selection: newSelection,
+      tabs: [],
+      activeTabIndex: -1,
+    });
+    get().setDirty(true);
+    get().forceRedraw();
   },
 
   // Frame and runtime
@@ -160,7 +241,7 @@ export const useAppStore = create((set, get) => ({
     const { network } = get();
     if (network) network.stop();
     get().setDirty(false);
-    set({ filePath: undefined, tabs: [], activeTabIndex: -1, selection: new Set() });
+    set({ filePath: undefined, tabs: [], activeTabIndex: -1, selection: new Set(), undoStack: [], redoStack: [] });
     window.desktop.stopOscServer();
   },
   async newProject() {
@@ -224,6 +305,7 @@ export const useAppStore = create((set, get) => ({
     set({ selection: new Set() });
   },
   deleteSelection() {
+    get().pushSnapshot();
     const { selection, network } = get();
     network.deleteNodes(Array.from(selection));
     get().setDirty(true);
@@ -244,6 +326,7 @@ export const useAppStore = create((set, get) => ({
     }
   },
   buildSource(nodeType, source) {
+    get().pushSnapshot();
     const { network } = get();
     network.setNodeTypeSource(nodeType, source);
     get().sourceModified(nodeType, null, false);
@@ -253,18 +336,25 @@ export const useAppStore = create((set, get) => ({
 
   // Ports
   changePortValue(node, portName, value) {
+    const now = Date.now();
+    if (now - get()._lastPortValueSnapshotTime > 500) {
+      get().pushSnapshot();
+      set({ _lastPortValueSnapshotTime: now });
+    }
     const { network } = get();
     network.setPortValue(node, portName, value);
     get().setDirty(true);
     get().forceRedraw();
   },
   changePortExpression(node, portName, expression) {
+    get().pushSnapshot();
     const { network } = get();
     network.setPortExpression(node, portName, expression);
     get().setDirty(true);
     get().forceRedraw();
   },
   revertPortValue(node, portName) {
+    get().pushSnapshot();
     const port = node.inPorts.find((p) => p.name === portName);
     const defaultValue = JSON.parse(JSON.stringify(port.defaultValue));
     const { network } = get();
@@ -273,6 +363,7 @@ export const useAppStore = create((set, get) => ({
     get().forceRedraw();
   },
   togglePortExpression(node, portName) {
+    get().pushSnapshot();
     const port = node.inPorts.find((p) => p.name === portName);
     const expression = JSON.stringify(port.value);
     const { network } = get();
@@ -281,6 +372,7 @@ export const useAppStore = create((set, get) => ({
     get().forceRedraw();
   },
   deletePortExpression(node, portName) {
+    get().pushSnapshot();
     const { network } = get();
     network.deletePortExpression(node, portName);
     get().setDirty(true);
@@ -307,6 +399,7 @@ export const useAppStore = create((set, get) => ({
     set({ showForkDialog: false });
   },
   forkNodeType(nodeType, newName, newTypeName, nodes = []) {
+    get().pushSnapshot();
     const { network, tabs } = get();
     const newNodeType = network.forkNodeType(nodeType, newName, newTypeName);
     for (const node of nodes) network.changeNodeType(node, newNodeType);
@@ -334,6 +427,7 @@ export const useAppStore = create((set, get) => ({
     set({ showProjectSettingsDialog: false });
   },
   createNode(nodeType) {
+    get().pushSnapshot();
     const { lastNetworkPoint, network, pendingConnectionPort } = get();
     const newNode = network.createNode(nodeType.type, lastNetworkPoint.x, lastNetworkPoint.y);
     // If there's a pending connection (from dragging an output port to empty space),
@@ -356,6 +450,7 @@ export const useAppStore = create((set, get) => ({
   },
   renameNode(node, newName) {
     if (newName.trim().length === 0) return;
+    get().pushSnapshot();
     const { network } = get();
     network.renameNode(node, newName);
     get().setDirty(true);
@@ -363,12 +458,14 @@ export const useAppStore = create((set, get) => ({
     get().forceRedraw();
   },
   connect(outPort, inPort) {
+    get().pushSnapshot();
     const { network } = get();
     network.connect(outPort, inPort);
     get().setDirty(true);
     get().forceRedraw();
   },
   disconnect(inPort) {
+    get().pushSnapshot();
     const { network } = get();
     network.disconnect(inPort);
     get().setDirty(true);
@@ -428,6 +525,7 @@ export const useAppStore = create((set, get) => ({
   },
 
   changeProjectSetting(setting, value) {
+    get().pushSnapshot();
     const { network } = get();
     network.setSetting(setting, value);
     if (setting === 'oscEnabled') {
@@ -480,6 +578,18 @@ export const useAppStore = create((set, get) => ({
   },
   handleMenuEvent(name, args) {
     switch (name) {
+      case 'undo': {
+        const tag = document.activeElement?.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+        get().undo();
+        break;
+      }
+      case 'redo': {
+        const tag = document.activeElement?.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+        get().redo();
+        break;
+      }
       case 'new':
         get().newProject();
         break;


### PR DESCRIPTION
Snapshot-based undo/redo using Network.serialize()/parse(), capturing full network state + selection before each mutation. Supports Ctrl+Z / Cmd+Z (undo) and Ctrl+Shift+Z / Cmd+Shift+Z / Ctrl+Y (redo) with proper node lifecycle (onStop/onStart) on restore.

Instrumented actions: create/delete nodes, connect/disconnect ports, change port values (throttled for drag), expressions, rename, fork, build source, and project settings. Node dragging captures snapshot on drag start and now correctly marks project as dirty.