### PR TITLE
Add undo/redo with fixes for stale refs, focus guard, and snapshot timing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,6 @@
       "version": "7.28.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -259,7 +258,6 @@
     "node_modules/@babel/runtime": {
       "version": "7.28.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -692,6 +690,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -713,6 +712,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -729,6 +729,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -743,6 +744,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2761,7 +2763,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3265,7 +3266,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -3880,7 +3880,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-env": {
       "version": "10.1.0",
@@ -4094,7 +4095,6 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -4401,6 +4401,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -4421,6 +4422,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -6086,6 +6088,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -6565,7 +6568,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6587,6 +6589,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -6604,6 +6607,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -6728,7 +6732,6 @@
     "node_modules/react": {
       "version": "19.2.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6736,7 +6739,6 @@
     "node_modules/react-dom": {
       "version": "19.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6917,7 +6919,6 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -7420,6 +7421,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -7482,7 +7484,8 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/temp/node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -7490,6 +7493,7 @@
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -7502,6 +7506,7 @@
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -7523,6 +7528,7 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -7537,6 +7543,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -7770,7 +7777,6 @@
       "version": "7.1.11",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -476,6 +476,7 @@ function createApplicationMenu() {
     submenu: [
       { label: 'Undo', accelerator: 'CmdOrCtrl+Z', click: emit('undo') },
       { label: 'Redo', accelerator: 'CmdOrCtrl+Shift+Z', click: emit('redo') },
+      { label: 'Redo', accelerator: 'CmdOrCtrl+Y', click: emit('redo'), visible: false },
       { type: 'separator' },
       { role: 'cut' },
       { role: 'copy' },

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -453,7 +453,20 @@ function createApplicationMenu() {
     ],
   };
 
-  const template = [...(isMac ? [macAppMenu] : []), fileMenu, { role: 'editMenu' }, viewMenu, { role: 'windowMenu' }];
+  const editMenu = {
+    label: 'Edit',
+    submenu: [
+      { label: 'Undo', accelerator: 'CmdOrCtrl+Z', click: emit('undo') },
+      { label: 'Redo', accelerator: 'CmdOrCtrl+Shift+Z', click: emit('redo') },
+      { type: 'separator' },
+      { role: 'cut' },
+      { role: 'copy' },
+      { role: 'paste' },
+      { role: 'selectAll' },
+    ],
+  };
+
+  const template = [...(isMac ? [macAppMenu] : []), fileMenu, editMenu, viewMenu, { role: 'windowMenu' }];
   const menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);
 }

--- a/src/model/Network.js
+++ b/src/model/Network.js
@@ -284,13 +284,13 @@ export default class Network {
     for (const node of this.nodes) {
       const values = {};
       for (const port of node.inPorts) {
-        if (port.type === PORT_TYPE_IMAGE || (port.type === PORT_TYPE_BOOLEAN && port._value.type !== 'expression')) continue;
+        if (port.type === PORT_TYPE_IMAGE) continue;
         if (this.isConnected(port)) continue;
         if (port._value.type === 'expression') {
           values[port.name] = structuredClone(port._value);
         } else if (JSON.stringify(port.value) !== JSON.stringify(port.defaultValue)) {
           let value;
-          if (port.type === PORT_TYPE_TOGGLE) {
+          if (port.type === PORT_TYPE_TOGGLE || port.type === PORT_TYPE_BOOLEAN) {
             value = port.value;
           } else if (port.type === PORT_TYPE_NUMBER) {
             value = port.value;

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -71,11 +71,27 @@ export default function App(props) {
     startNetwork();
   }, [startNetwork]);
 
+  const undo = useAppStore((state) => state.undo);
+  const redo = useAppStore((state) => state.redo);
+
   const onKeyDown = useCallback(
     (e) => {
       if (e.keyCode === 27 && useAppStore.getState().fullscreen) toggleFullscreen();
+      if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+      if ((e.ctrlKey || e.metaKey) && !e.shiftKey && e.key === 'z') {
+        e.preventDefault();
+        undo();
+      }
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'z') {
+        e.preventDefault();
+        redo();
+      }
+      if ((e.ctrlKey || e.metaKey) && e.key === 'y') {
+        e.preventDefault();
+        redo();
+      }
     },
-    [toggleFullscreen],
+    [toggleFullscreen, undo, redo],
   );
 
   // Wire listeners and RAF loop explicitly here

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -107,27 +107,11 @@ export default function App(props) {
     }
   }, [gpuStatus, startNetwork, props.filePath, openFile]);
 
-  const undo = useAppStore((state) => state.undo);
-  const redo = useAppStore((state) => state.redo);
-
   const onKeyDown = useCallback(
     (e) => {
       if (e.keyCode === 27 && useAppStore.getState().fullscreen) toggleFullscreen();
-      if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
-      if ((e.ctrlKey || e.metaKey) && !e.shiftKey && e.key === 'z') {
-        e.preventDefault();
-        undo();
-      }
-      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'z') {
-        e.preventDefault();
-        redo();
-      }
-      if ((e.ctrlKey || e.metaKey) && e.key === 'y') {
-        e.preventDefault();
-        redo();
-      }
     },
-    [toggleFullscreen, undo, redo],
+    [toggleFullscreen],
   );
 
   // Wire listeners and RAF loop explicitly here

--- a/src/ui/NetworkEditor.jsx
+++ b/src/ui/NetworkEditor.jsx
@@ -179,6 +179,7 @@ export default function NetworkEditor() {
   const resizeObserverRef = useRef(null);
   const defaultTextureViewRef = useRef(null);
   const rafIdRef = useRef(0);
+  const dragSnapshotTakenRef = useRef(false);
 
   // On component mount
   useEffect(() => {
@@ -421,7 +422,7 @@ export default function NetworkEditor() {
           dragModeRef.current = DRAG_MODE_IDLE;
         } else {
           dragModeRef.current = DRAG_MODE_DRAG_NODE;
-          useAppStore.getState().pushSnapshot();
+          dragSnapshotTakenRef.current = false;
           const currentSelection = useAppStore.getState().selection;
           if (!currentSelection.has(node)) {
             selectNode(node);
@@ -453,6 +454,10 @@ export default function NetworkEditor() {
     } else if (dragModeRef.current === DRAG_MODE_SELECTING) {
       // Box selections: nothing is needed here
     } else if (dragModeRef.current === DRAG_MODE_DRAG_NODE) {
+      if (!dragSnapshotTakenRef.current) {
+        useAppStore.getState().pushSnapshot();
+        dragSnapshotTakenRef.current = true;
+      }
       const currentSelection = useAppStore.getState().selection;
       currentSelection.forEach((node) => {
         node.x += dx / stateRef.current.scale;
@@ -503,7 +508,7 @@ export default function NetworkEditor() {
       }
       selectNodes(newSelection);
     }
-    if (dragModeRef.current === DRAG_MODE_DRAG_NODE) {
+    if (dragModeRef.current === DRAG_MODE_DRAG_NODE && dragSnapshotTakenRef.current) {
       useAppStore.getState().setDirty(true);
     }
     window.removeEventListener('mousemove', onMouseDrag);

--- a/src/ui/NetworkEditor.jsx
+++ b/src/ui/NetworkEditor.jsx
@@ -358,6 +358,7 @@ export default function NetworkEditor({ offscreenCanvas }) {
           dragModeRef.current = DRAG_MODE_IDLE;
         } else {
           dragModeRef.current = DRAG_MODE_DRAG_NODE;
+          useAppStore.getState().pushSnapshot();
           const currentSelection = useAppStore.getState().selection;
           if (!currentSelection.has(node)) {
             selectNode(node);
@@ -438,6 +439,9 @@ export default function NetworkEditor({ offscreenCanvas }) {
         }
       }
       selectNodes(newSelection);
+    }
+    if (dragModeRef.current === DRAG_MODE_DRAG_NODE) {
+      useAppStore.getState().setDirty(true);
     }
     window.removeEventListener('mousemove', onMouseDrag);
     window.removeEventListener('mouseup', onMouseUp);

--- a/src/ui/ParamsEditor.jsx
+++ b/src/ui/ParamsEditor.jsx
@@ -33,7 +33,7 @@ function roundToMaxPlaces(v, places = 4) {
   return (Math.round(v * Math.pow(10, places)) / Math.pow(10, places)).toString();
 }
 
-function NumberDrag({ label, value, min, max, step, disabled, direction, onChange }) {
+function NumberDrag({ label, value, min, max, step, disabled, direction, onChange, onBeforeChange }) {
   const [inputState, setInputState] = useState(NUMBER_DRAG_IDLE);
   const [tempValue, setTempValue] = useState('');
   const inputRef = useRef(null);
@@ -41,6 +41,23 @@ function NumberDrag({ label, value, min, max, step, disabled, direction, onChang
   const dyRef = useRef(0);
   const startValueRef = useRef(null);
   const inputStateRef = useRef(NUMBER_DRAG_IDLE);
+  const beforeChangeCalledRef = useRef(false);
+
+  // Keep latest props accessible to stable event handler refs
+  const onChangeRef = useRef(onChange);
+  const onBeforeChangeRef = useRef(onBeforeChange);
+  const stepRef = useRef(step);
+  const minRef = useRef(min);
+  const maxRef = useRef(max);
+  const directionRef = useRef(direction);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+    onBeforeChangeRef.current = onBeforeChange;
+    stepRef.current = step;
+    minRef.current = min;
+    maxRef.current = max;
+    directionRef.current = direction;
+  });
 
   useEffect(() => {
     inputStateRef.current = inputState;
@@ -55,16 +72,20 @@ function NumberDrag({ label, value, min, max, step, disabled, direction, onChang
     dyRef.current += e.movementY;
     const totalDistance = Math.abs(dxRef.current) + Math.abs(dyRef.current);
     if (totalDistance <= 2) return;
+    if (!beforeChangeCalledRef.current) {
+      onBeforeChangeRef.current?.();
+      beforeChangeCalledRef.current = true;
+    }
     setInputState(NUMBER_DRAG_DRAGGING);
-    if (direction === 'xy') {
-      const newX = startValueRef.current.x + dxRef.current * step;
-      const newY = startValueRef.current.y + dyRef.current * step;
-      onChange(new Point(newX, newY));
+    if (directionRef.current === 'xy') {
+      const newX = startValueRef.current.x + dxRef.current * stepRef.current;
+      const newY = startValueRef.current.y + dyRef.current * stepRef.current;
+      onChangeRef.current(new Point(newX, newY));
     } else {
-      let newValue = startValueRef.current + dxRef.current * step;
-      if (min !== undefined && newValue < min) newValue = min;
-      if (max !== undefined && newValue > max) newValue = max;
-      onChange(newValue);
+      let newValue = startValueRef.current + dxRef.current * stepRef.current;
+      if (minRef.current !== undefined && newValue < minRef.current) newValue = minRef.current;
+      if (maxRef.current !== undefined && newValue > maxRef.current) newValue = maxRef.current;
+      onChangeRef.current(newValue);
     }
   }).current;
 
@@ -73,6 +94,7 @@ function NumberDrag({ label, value, min, max, step, disabled, direction, onChang
     window.removeEventListener('mousemove', onMouseMove);
     window.removeEventListener('mouseup', onMouseUp);
     document.exitPointerLock();
+    beforeChangeCalledRef.current = false;
     if (inputStateRef.current === NUMBER_DRAG_IDLE) {
       setInputState(NUMBER_DRAG_INPUT);
       setTempValue(roundToMaxPlaces(startValueRef.current));
@@ -88,6 +110,7 @@ function NumberDrag({ label, value, min, max, step, disabled, direction, onChang
     e.preventDefault();
     if (disabled) return;
     startValueRef.current = value;
+    beforeChangeCalledRef.current = false;
     e.target.requestPointerLock();
     window.addEventListener('mousemove', onMouseMove);
     window.addEventListener('mouseup', onMouseUp);
@@ -110,6 +133,7 @@ function NumberDrag({ label, value, min, max, step, disabled, direction, onChang
     if (isNaN(newValue)) return;
     if (min !== undefined && newValue < min) newValue = min;
     if (max !== undefined && newValue > max) newValue = max;
+    onBeforeChange?.();
     onChange(newValue);
     setInputState(NUMBER_DRAG_IDLE);
   };
@@ -158,7 +182,7 @@ function NumberDrag({ label, value, min, max, step, disabled, direction, onChang
   }
 }
 
-function FloatParam({ port, label, value, min, max, step, disabled, onChange }) {
+function FloatParam({ port, label, value, min, max, step, disabled, onChange, onBeforeChange }) {
   const handleShowMenu = (e) => {
     e.preventDefault();
     e.stopPropagation();
@@ -168,7 +192,16 @@ function FloatParam({ port, label, value, min, max, step, disabled, onChange }) 
   return (
     <>
       <label className="text-right text-gray-500 whitespace-nowrap">{label}</label>
-      <NumberDrag label={label} value={value} min={min} max={max} step={step} disabled={disabled} onChange={onChange} />
+      <NumberDrag
+        label={label}
+        value={value}
+        min={min}
+        max={max}
+        step={step}
+        disabled={disabled}
+        onChange={onChange}
+        onBeforeChange={onBeforeChange}
+      />
       <Icon className="params__more" name="dots-vertical-rounded" fill="white" size="16" onClick={handleShowMenu} />
     </>
   );
@@ -209,22 +242,39 @@ function ExpressionParam({ port, label, expression, onChange }) {
   );
 }
 
-function StringParam({ port, label, value, disabled, onChange }) {
+function StringParam({ port, label, value, disabled, onChange, onBeforeChange }) {
+  const onChangeRef = useRef(onChange);
+  const onBeforeChangeRef = useRef(onBeforeChange);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+    onBeforeChangeRef.current = onBeforeChange;
+  });
+
+  const hasPushedSnapshotRef = useRef(false);
+  const prevValueRef = useRef(value);
+  if (prevValueRef.current !== value) {
+    hasPushedSnapshotRef.current = false;
+    prevValueRef.current = value;
+  }
   const throttledOnChange = useRef(null);
   if (!throttledOnChange.current) {
     let lastCall = 0;
     let timer = null;
     throttledOnChange.current = (...args) => {
+      if (!hasPushedSnapshotRef.current) {
+        onBeforeChangeRef.current?.();
+        hasPushedSnapshotRef.current = true;
+      }
       const now = Date.now();
       const remaining = 200 - (now - lastCall);
       clearTimeout(timer);
       if (remaining <= 0) {
         lastCall = now;
-        onChange(...args);
+        onChangeRef.current(...args);
       } else {
         timer = setTimeout(() => {
           lastCall = Date.now();
-          onChange(...args);
+          onChangeRef.current(...args);
         }, remaining);
       }
     };
@@ -296,6 +346,7 @@ function ColorParam({ port, label, value, editorSplitterWidth, onChange }) {
   const [pickerVisible, setPickerVisible] = useState(false);
 
   const handleToggleColorPicker = () => {
+    if (!pickerVisible) useAppStore.getState().pushSnapshot();
     setPickerVisible(!pickerVisible);
   };
 
@@ -346,7 +397,7 @@ function ColorParam({ port, label, value, editorSplitterWidth, onChange }) {
   );
 }
 
-function PointParam({ port, label, value, onChange }) {
+function PointParam({ port, label, value, onChange, onBeforeChange }) {
   const handleShowMenu = (e) => {
     e.preventDefault();
     e.stopPropagation();
@@ -357,8 +408,20 @@ function PointParam({ port, label, value, onChange }) {
     <>
       <label className="text-right text-gray-500 py-2 whitespace-nowrap">{label}</label>
       <span className="flex gap-2">
-        <NumberDrag label={label} value={value.x} step={0.1} onChange={(v) => onChange(new Point(v, value.y))} />
-        <NumberDrag label={label} value={value.y} step={0.1} onChange={(v) => onChange(new Point(value.x, v))} />
+        <NumberDrag
+          label={label}
+          value={value.x}
+          step={0.1}
+          onChange={(v) => onChange(new Point(v, value.y))}
+          onBeforeChange={onBeforeChange}
+        />
+        <NumberDrag
+          label={label}
+          value={value.y}
+          step={0.1}
+          onChange={(v) => onChange(new Point(value.x, v))}
+          onBeforeChange={onBeforeChange}
+        />
       </span>
       <Icon className="params__more" name="dots-vertical-rounded" fill="white" size="16" onClick={handleShowMenu} />
     </>
@@ -521,19 +584,28 @@ export default function ParamsEditor() {
   }, []);
 
   const handleChangePortValue = (portName, value) => {
-    selection.forEach((node) => {
+    useAppStore.getState().selection.forEach((node) => {
       changePortValue(node, portName, value);
     });
   };
 
+  const handleChangePortValueWithSnapshot = (portName, value) => {
+    useAppStore.getState().pushSnapshot();
+    handleChangePortValue(portName, value);
+  };
+
+  const handlePushSnapshot = () => {
+    useAppStore.getState().pushSnapshot();
+  };
+
   const handleChangePortExpression = (portName, expression) => {
-    selection.forEach((node) => {
+    useAppStore.getState().selection.forEach((node) => {
       changePortExpression(node, portName, expression);
     });
   };
 
   const handleTriggerButton = (port) => {
-    selection.forEach((node) => {
+    useAppStore.getState().selection.forEach((node) => {
       triggerButton(node, port);
     });
   };
@@ -578,7 +650,7 @@ export default function ParamsEditor() {
           label={port.label}
           value={port.value}
           disabled={network.isConnected(port)}
-          onChange={(value) => handleChangePortValue(port.name, value)}
+          onChange={(value) => handleChangePortValueWithSnapshot(port.name, value)}
         />
       );
     } else if (port.type === PORT_TYPE_NUMBER) {
@@ -593,6 +665,7 @@ export default function ParamsEditor() {
           step={port.step}
           disabled={network.isConnected(port)}
           onChange={(value) => handleChangePortValue(port.name, value)}
+          onBeforeChange={handlePushSnapshot}
         />
       );
     } else if (port.type === PORT_TYPE_STRING) {
@@ -604,6 +677,7 @@ export default function ParamsEditor() {
           value={port.value}
           disabled={network.isConnected(port)}
           onChange={(value) => handleChangePortValue(port.name, value)}
+          onBeforeChange={handlePushSnapshot}
         />
       );
     } else if (port.type === PORT_TYPE_SELECT) {
@@ -615,7 +689,7 @@ export default function ParamsEditor() {
           value={port.value}
           options={port.options}
           disabled={network.isConnected(port)}
-          onChange={(value) => handleChangePortValue(port.name, value)}
+          onChange={(value) => handleChangePortValueWithSnapshot(port.name, value)}
         />
       );
     } else if (port.type === PORT_TYPE_POINT) {
@@ -627,6 +701,7 @@ export default function ParamsEditor() {
           value={port.value}
           disabled={network.isConnected(port)}
           onChange={(value) => handleChangePortValue(port.name, value)}
+          onBeforeChange={handlePushSnapshot}
         />
       );
     } else if (port.type === PORT_TYPE_COLOR) {
@@ -650,7 +725,7 @@ export default function ParamsEditor() {
           value={port.value}
           fileType={port.fileType}
           disabled={network.isConnected(port)}
-          onChange={(value) => handleChangePortValue(port.name, value)}
+          onChange={(value) => handleChangePortValueWithSnapshot(port.name, value)}
         />
       );
     } else if (port.type === PORT_TYPE_DIRECTORY) {
@@ -661,7 +736,7 @@ export default function ParamsEditor() {
           label={port.label}
           value={port.value}
           disabled={network.isConnected(port)}
-          onChange={(value) => handleChangePortValue(port.name, value)}
+          onChange={(value) => handleChangePortValueWithSnapshot(port.name, value)}
         />
       );
     }

--- a/src/ui/store.js
+++ b/src/ui/store.js
@@ -6,6 +6,8 @@ import { upgradeProject } from '../file-format';
 import { PORT_TYPE_IMAGE } from '../model/Port';
 
 // Centralized app UI state using Zustand
+const HISTORY_LIMIT = 50;
+
 const initialLibrary = new Library();
 const initialNetwork = new Network(initialLibrary);
 initialNetwork.parse(getDefaultNetwork());
@@ -38,6 +40,9 @@ export const useAppStore = create((set, get) => ({
   midiMessageMap: new Map(),
   midiProgramChangeMap: new Map(),
   midiDevices: [],
+  undoStack: [],
+  redoStack: [],
+  _lastPortValueSnapshotTime: 0,
 
   // Generic setter helper
   set: (partial) => set(partial),
@@ -50,6 +55,82 @@ export const useAppStore = create((set, get) => ({
   setDirty(dirty) {
     window.desktop.setDocumentEdited(dirty);
     set({ dirty });
+  },
+
+  // Undo/Redo
+  pushSnapshot() {
+    const { network, selection, undoStack } = get();
+    const snapshot = {
+      network: network.serialize(),
+      selectedNodeIds: Array.from(selection).map((n) => n.id),
+    };
+    const newStack = [...undoStack, snapshot];
+    if (newStack.length > HISTORY_LIMIT) {
+      newStack.shift();
+    }
+    set({ undoStack: newStack, redoStack: [] });
+  },
+  async undo() {
+    const { undoStack, redoStack, network, selection, library } = get();
+    if (undoStack.length === 0) return;
+    const currentSnapshot = {
+      network: network.serialize(),
+      selectedNodeIds: Array.from(selection).map((n) => n.id),
+    };
+    const newRedoStack = [...redoStack, currentSnapshot];
+    const newUndoStack = [...undoStack];
+    const snapshot = newUndoStack.pop();
+    network.stop();
+    const newNetwork = new Network(library);
+    newNetwork.parse(snapshot.network);
+    await newNetwork.start();
+    newNetwork.doFrame();
+    const newSelection = new Set();
+    for (const id of snapshot.selectedNodeIds) {
+      const node = newNetwork.nodes.find((n) => n.id === id);
+      if (node) newSelection.add(node);
+    }
+    set({
+      network: newNetwork,
+      undoStack: newUndoStack,
+      redoStack: newRedoStack,
+      selection: newSelection,
+      tabs: [],
+      activeTabIndex: -1,
+    });
+    get().setDirty(true);
+    get().forceRedraw();
+  },
+  async redo() {
+    const { undoStack, redoStack, network, selection, library } = get();
+    if (redoStack.length === 0) return;
+    const currentSnapshot = {
+      network: network.serialize(),
+      selectedNodeIds: Array.from(selection).map((n) => n.id),
+    };
+    const newUndoStack = [...undoStack, currentSnapshot];
+    const newRedoStack = [...redoStack];
+    const snapshot = newRedoStack.pop();
+    network.stop();
+    const newNetwork = new Network(library);
+    newNetwork.parse(snapshot.network);
+    await newNetwork.start();
+    newNetwork.doFrame();
+    const newSelection = new Set();
+    for (const id of snapshot.selectedNodeIds) {
+      const node = newNetwork.nodes.find((n) => n.id === id);
+      if (node) newSelection.add(node);
+    }
+    set({
+      network: newNetwork,
+      undoStack: newUndoStack,
+      redoStack: newRedoStack,
+      selection: newSelection,
+      tabs: [],
+      activeTabIndex: -1,
+    });
+    get().setDirty(true);
+    get().forceRedraw();
   },
 
   // Frame and runtime
@@ -160,7 +241,7 @@ export const useAppStore = create((set, get) => ({
     const { network } = get();
     if (network) network.stop();
     get().setDirty(false);
-    set({ filePath: undefined, tabs: [], activeTabIndex: -1, selection: new Set() });
+    set({ filePath: undefined, tabs: [], activeTabIndex: -1, selection: new Set(), undoStack: [], redoStack: [] });
     window.desktop.stopOscServer();
   },
   async newProject() {
@@ -224,6 +305,7 @@ export const useAppStore = create((set, get) => ({
     set({ selection: new Set() });
   },
   deleteSelection() {
+    get().pushSnapshot();
     const { selection, network } = get();
     network.deleteNodes(Array.from(selection));
     get().setDirty(true);
@@ -244,6 +326,7 @@ export const useAppStore = create((set, get) => ({
     }
   },
   buildSource(nodeType, source) {
+    get().pushSnapshot();
     const { network } = get();
     network.setNodeTypeSource(nodeType, source);
     get().sourceModified(nodeType, null, false);
@@ -253,18 +336,25 @@ export const useAppStore = create((set, get) => ({
 
   // Ports
   changePortValue(node, portName, value) {
+    const now = Date.now();
+    if (now - get()._lastPortValueSnapshotTime > 500) {
+      get().pushSnapshot();
+      set({ _lastPortValueSnapshotTime: now });
+    }
     const { network } = get();
     network.setPortValue(node, portName, value);
     get().setDirty(true);
     get().forceRedraw();
   },
   changePortExpression(node, portName, expression) {
+    get().pushSnapshot();
     const { network } = get();
     network.setPortExpression(node, portName, expression);
     get().setDirty(true);
     get().forceRedraw();
   },
   revertPortValue(node, portName) {
+    get().pushSnapshot();
     const port = node.inPorts.find((p) => p.name === portName);
     const defaultValue = JSON.parse(JSON.stringify(port.defaultValue));
     const { network } = get();
@@ -273,6 +363,7 @@ export const useAppStore = create((set, get) => ({
     get().forceRedraw();
   },
   togglePortExpression(node, portName) {
+    get().pushSnapshot();
     const port = node.inPorts.find((p) => p.name === portName);
     const expression = JSON.stringify(port.value);
     const { network } = get();
@@ -281,6 +372,7 @@ export const useAppStore = create((set, get) => ({
     get().forceRedraw();
   },
   deletePortExpression(node, portName) {
+    get().pushSnapshot();
     const { network } = get();
     network.deletePortExpression(node, portName);
     get().setDirty(true);
@@ -307,6 +399,7 @@ export const useAppStore = create((set, get) => ({
     set({ showForkDialog: false });
   },
   forkNodeType(nodeType, newName, newTypeName, nodes = []) {
+    get().pushSnapshot();
     const { network, tabs } = get();
     const newNodeType = network.forkNodeType(nodeType, newName, newTypeName);
     for (const node of nodes) network.changeNodeType(node, newNodeType);
@@ -334,6 +427,7 @@ export const useAppStore = create((set, get) => ({
     set({ showProjectSettingsDialog: false });
   },
   createNode(nodeType) {
+    get().pushSnapshot();
     const { lastNetworkPoint, network, pendingConnectionPort } = get();
     const newNode = network.createNode(nodeType.type, lastNetworkPoint.x, lastNetworkPoint.y);
     // If there's a pending connection (from dragging an output port to empty space),
@@ -356,6 +450,7 @@ export const useAppStore = create((set, get) => ({
   },
   renameNode(node, newName) {
     if (newName.trim().length === 0) return;
+    get().pushSnapshot();
     const { network } = get();
     network.renameNode(node, newName);
     get().setDirty(true);
@@ -363,12 +458,14 @@ export const useAppStore = create((set, get) => ({
     get().forceRedraw();
   },
   connect(outPort, inPort) {
+    get().pushSnapshot();
     const { network } = get();
     network.connect(outPort, inPort);
     get().setDirty(true);
     get().forceRedraw();
   },
   disconnect(inPort) {
+    get().pushSnapshot();
     const { network } = get();
     network.disconnect(inPort);
     get().setDirty(true);
@@ -428,6 +525,7 @@ export const useAppStore = create((set, get) => ({
   },
 
   changeProjectSetting(setting, value) {
+    get().pushSnapshot();
     const { network } = get();
     network.setSetting(setting, value);
     if (setting === 'oscEnabled') {
@@ -480,6 +578,18 @@ export const useAppStore = create((set, get) => ({
   },
   handleMenuEvent(name, args) {
     switch (name) {
+      case 'undo': {
+        const tag = document.activeElement?.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+        get().undo();
+        break;
+      }
+      case 'redo': {
+        const tag = document.activeElement?.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+        get().redo();
+        break;
+      }
       case 'new':
         get().newProject();
         break;

--- a/src/ui/store.js
+++ b/src/ui/store.js
@@ -44,7 +44,7 @@ export const useAppStore = create((set, get) => ({
   migration: null, // { phase, webglTypeCount, nodeCount, nodesCompleted, error, _pendingProject, _pendingFilePath, _stopPolling }
   undoStack: [],
   redoStack: [],
-  _lastPortValueSnapshotTime: 0,
+  _undoInProgress: false,
 
   // Generic setter helper
   set: (partial) => set(partial),
@@ -73,66 +73,97 @@ export const useAppStore = create((set, get) => ({
     set({ undoStack: newStack, redoStack: [] });
   },
   async undo() {
+    if (get()._undoInProgress) return;
     const { undoStack, redoStack, network, selection, library } = get();
     if (undoStack.length === 0) return;
-    const currentSnapshot = {
-      network: network.serialize(),
-      selectedNodeIds: Array.from(selection).map((n) => n.id),
-    };
-    const newRedoStack = [...redoStack, currentSnapshot];
-    const newUndoStack = [...undoStack];
-    const snapshot = newUndoStack.pop();
-    network.stop();
-    const newNetwork = new Network(library);
-    newNetwork.parse(snapshot.network);
-    await newNetwork.start();
-    newNetwork.doFrame();
-    const newSelection = new Set();
-    for (const id of snapshot.selectedNodeIds) {
-      const node = newNetwork.nodes.find((n) => n.id === id);
-      if (node) newSelection.add(node);
+    set({ _undoInProgress: true });
+    try {
+      const currentSnapshot = {
+        network: network.serialize(),
+        selectedNodeIds: Array.from(selection).map((n) => n.id),
+      };
+      const newRedoStack = [...redoStack, currentSnapshot];
+      const newUndoStack = [...undoStack];
+      const snapshot = newUndoStack.pop();
+      network.stop();
+      const newNetwork = new Network(library);
+      newNetwork.parse(snapshot.network);
+      await newNetwork.start();
+      newNetwork.doFrame();
+      const newSelection = new Set();
+      for (const id of snapshot.selectedNodeIds) {
+        const node = newNetwork.nodes.find((n) => n.id === id);
+        if (node) newSelection.add(node);
+      }
+      const currentTabs = get().tabs;
+      const newTabs = [];
+      for (const tab of currentTabs) {
+        const newNodeType = newNetwork.findNodeType(tab.nodeType.type);
+        if (newNodeType) {
+          newTabs.push({ ...tab, nodeType: newNodeType, modified: false, uncommittedSource: null });
+        }
+      }
+      set({
+        network: newNetwork,
+        undoStack: newUndoStack,
+        redoStack: newRedoStack,
+        selection: newSelection,
+        tabs: newTabs,
+        activeTabIndex: newTabs.length > 0 ? Math.min(get().activeTabIndex, newTabs.length - 1) : -1,
+      });
+      get().setDirty(true);
+      get().forceRedraw();
+    } finally {
+      set({ _undoInProgress: false });
     }
-    set({
-      network: newNetwork,
-      undoStack: newUndoStack,
-      redoStack: newRedoStack,
-      selection: newSelection,
-      tabs: [],
-      activeTabIndex: -1,
-    });
-    get().setDirty(true);
-    get().forceRedraw();
   },
   async redo() {
+    if (get()._undoInProgress) return;
     const { undoStack, redoStack, network, selection, library } = get();
     if (redoStack.length === 0) return;
-    const currentSnapshot = {
-      network: network.serialize(),
-      selectedNodeIds: Array.from(selection).map((n) => n.id),
-    };
-    const newUndoStack = [...undoStack, currentSnapshot];
-    const newRedoStack = [...redoStack];
-    const snapshot = newRedoStack.pop();
-    network.stop();
-    const newNetwork = new Network(library);
-    newNetwork.parse(snapshot.network);
-    await newNetwork.start();
-    newNetwork.doFrame();
-    const newSelection = new Set();
-    for (const id of snapshot.selectedNodeIds) {
-      const node = newNetwork.nodes.find((n) => n.id === id);
-      if (node) newSelection.add(node);
+    set({ _undoInProgress: true });
+    try {
+      const currentSnapshot = {
+        network: network.serialize(),
+        selectedNodeIds: Array.from(selection).map((n) => n.id),
+      };
+      const newUndoStack = [...undoStack, currentSnapshot];
+      if (newUndoStack.length > HISTORY_LIMIT) {
+        newUndoStack.shift();
+      }
+      const newRedoStack = [...redoStack];
+      const snapshot = newRedoStack.pop();
+      network.stop();
+      const newNetwork = new Network(library);
+      newNetwork.parse(snapshot.network);
+      await newNetwork.start();
+      newNetwork.doFrame();
+      const newSelection = new Set();
+      for (const id of snapshot.selectedNodeIds) {
+        const node = newNetwork.nodes.find((n) => n.id === id);
+        if (node) newSelection.add(node);
+      }
+      const currentTabs = get().tabs;
+      const newTabs = [];
+      for (const tab of currentTabs) {
+        const newNodeType = newNetwork.findNodeType(tab.nodeType.type);
+        if (newNodeType) {
+          newTabs.push({ ...tab, nodeType: newNodeType, modified: false, uncommittedSource: null });
+        }
+      }
+      set({
+        network: newNetwork,
+        undoStack: newUndoStack,
+        redoStack: newRedoStack,
+        selection: newSelection,
+        tabs: newTabs,
+        activeTabIndex: newTabs.length > 0 ? Math.min(get().activeTabIndex, newTabs.length - 1) : -1,
+      });
+      get().setDirty(true);
+      get().forceRedraw();
+    } finally {
+      set({ _undoInProgress: false });
     }
-    set({
-      network: newNetwork,
-      undoStack: newUndoStack,
-      redoStack: newRedoStack,
-      selection: newSelection,
-      tabs: [],
-      activeTabIndex: -1,
-    });
-    get().setDirty(true);
-    get().forceRedraw();
   },
 
   // Frame and runtime
@@ -442,11 +473,6 @@ export const useAppStore = create((set, get) => ({
 
   // Ports
   changePortValue(node, portName, value) {
-    const now = Date.now();
-    if (now - get()._lastPortValueSnapshotTime > 500) {
-      get().pushSnapshot();
-      set({ _lastPortValueSnapshotTime: now });
-    }
     const { network } = get();
     network.setPortValue(node, portName, value);
     get().setDirty(true);
@@ -654,6 +680,7 @@ export const useAppStore = create((set, get) => ({
         window.desktop.startOscServer(port);
       }
     }
+    get().setDirty(true);
     get().forceRedraw();
   },
 
@@ -684,14 +711,14 @@ export const useAppStore = create((set, get) => ({
   handleMenuEvent(name, args) {
     switch (name) {
       case 'undo': {
-        const tag = document.activeElement?.tagName;
-        if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+        const el = document.activeElement;
+        if (el?.tagName === 'TEXTAREA' || (el?.tagName === 'INPUT' && el.type !== 'checkbox')) return;
         get().undo();
         break;
       }
       case 'redo': {
-        const tag = document.activeElement?.tagName;
-        if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+        const el = document.activeElement;
+        if (el?.tagName === 'TEXTAREA' || (el?.tagName === 'INPUT' && el.type !== 'checkbox')) return;
         get().redo();
         break;
       }

--- a/src/ui/store.test.js
+++ b/src/ui/store.test.js
@@ -42,6 +42,8 @@ vi.mock('../model/Network', () => ({
       this.renameNode = vi.fn();
       this.connect = vi.fn();
       this.disconnect = vi.fn();
+      this.setSetting = vi.fn();
+      this.createNode = vi.fn(() => ({ id: 99, inPorts: [], outPorts: [] }));
     }
   },
   getDefaultNetwork: () => ({ nodes: [], connections: [], settings: { oscEnabled: false } }),
@@ -198,6 +200,390 @@ describe('useAppStore', () => {
     expect(network.doFrame).toHaveBeenCalledTimes(2);
   });
 
+  // ─── Undo/Redo ────────────────────────────────────────────────
+
+  describe('undo/redo', () => {
+    test('golden path: undo restores previous state, redo re-applies it', async () => {
+      const { useAppStore, networkModule } = await loadStore();
+      const network = new networkModule.default();
+      network.started = true;
+      let serializeCallCount = 0;
+      network.serialize = vi.fn(() => ({ version: 6, nodes: [], connections: [], state: `snapshot-${serializeCallCount++}` }));
+      useAppStore.setState({ network });
+
+      // Push a snapshot (captures state: snapshot-0), then simulate a mutation
+      useAppStore.getState().pushSnapshot();
+      expect(useAppStore.getState().undoStack).toHaveLength(1);
+      expect(useAppStore.getState().redoStack).toHaveLength(0);
+
+      // Undo: should stop old network, parse snapshot, start new network
+      await useAppStore.getState().undo();
+      const newNetwork = useAppStore.getState().network;
+      expect(network.stop).toHaveBeenCalled();
+      expect(newNetwork.parse).toHaveBeenCalledWith(expect.objectContaining({ state: 'snapshot-0' }));
+      expect(newNetwork.start).toHaveBeenCalled();
+      expect(newNetwork.doFrame).toHaveBeenCalled();
+      expect(useAppStore.getState().undoStack).toHaveLength(0);
+      expect(useAppStore.getState().redoStack).toHaveLength(1);
+
+      // Redo: should restore the state we undid from
+      await useAppStore.getState().redo();
+      const redoneNetwork = useAppStore.getState().network;
+      expect(redoneNetwork).not.toBe(newNetwork);
+      expect(useAppStore.getState().undoStack).toHaveLength(1);
+      expect(useAppStore.getState().redoStack).toHaveLength(0);
+    });
+
+    test('undo on empty stack does nothing', async () => {
+      const { useAppStore, networkModule } = await loadStore();
+      const network = new networkModule.default();
+      network.started = true;
+      useAppStore.setState({ network });
+
+      expect(useAppStore.getState().undoStack).toHaveLength(0);
+      await useAppStore.getState().undo();
+
+      // Network should not have been stopped or replaced
+      expect(network.stop).not.toHaveBeenCalled();
+      expect(useAppStore.getState().network).toBe(network);
+    });
+
+    test('redo on empty stack does nothing', async () => {
+      const { useAppStore, networkModule } = await loadStore();
+      const network = new networkModule.default();
+      network.started = true;
+      useAppStore.setState({ network });
+
+      expect(useAppStore.getState().redoStack).toHaveLength(0);
+      await useAppStore.getState().redo();
+
+      expect(network.stop).not.toHaveBeenCalled();
+      expect(useAppStore.getState().network).toBe(network);
+    });
+
+    test('new mutation clears redo stack', async () => {
+      const { useAppStore, networkModule } = await loadStore();
+      const network = new networkModule.default();
+      network.started = true;
+      useAppStore.setState({ network });
+
+      // Build up: push → undo → have redo entries
+      useAppStore.getState().pushSnapshot();
+      await useAppStore.getState().undo();
+      expect(useAppStore.getState().redoStack).toHaveLength(1);
+
+      // New mutation should clear redo
+      useAppStore.getState().pushSnapshot();
+      expect(useAppStore.getState().redoStack).toHaveLength(0);
+    });
+
+    test('history limit is enforced on undo stack', async () => {
+      const { useAppStore, networkModule } = await loadStore();
+      const network = new networkModule.default();
+      network.started = true;
+      useAppStore.setState({ network });
+
+      // Push more than HISTORY_LIMIT (50) snapshots
+      for (let i = 0; i < 55; i++) {
+        useAppStore.getState().pushSnapshot();
+      }
+      expect(useAppStore.getState().undoStack).toHaveLength(50);
+    });
+
+    test('re-entrancy guard prevents concurrent undo calls', async () => {
+      const { useAppStore, networkModule } = await loadStore();
+      const network = new networkModule.default();
+      network.started = true;
+      useAppStore.setState({ network });
+
+      useAppStore.getState().pushSnapshot();
+      useAppStore.getState().pushSnapshot();
+
+      // Start two undos simultaneously
+      const p1 = useAppStore.getState().undo();
+      const p2 = useAppStore.getState().undo();
+      await Promise.all([p1, p2]);
+
+      // Only one undo should have executed (stack went from 2 → 1, not 2 → 0)
+      expect(useAppStore.getState().undoStack).toHaveLength(1);
+    });
+
+    test('re-entrancy guard prevents concurrent redo calls', async () => {
+      const { useAppStore, networkModule } = await loadStore();
+      const network = new networkModule.default();
+      network.started = true;
+      useAppStore.setState({ network });
+
+      // Build redo stack: push 2, undo 2
+      useAppStore.getState().pushSnapshot();
+      useAppStore.getState().pushSnapshot();
+      await useAppStore.getState().undo();
+      await useAppStore.getState().undo();
+      expect(useAppStore.getState().redoStack).toHaveLength(2);
+
+      // Start two redos simultaneously
+      const p1 = useAppStore.getState().redo();
+      const p2 = useAppStore.getState().redo();
+      await Promise.all([p1, p2]);
+
+      // Only one redo should have executed
+      expect(useAppStore.getState().redoStack).toHaveLength(1);
+    });
+
+    test('undo/redo preserves selection by node id', async () => {
+      const { useAppStore, networkModule } = await loadStore();
+      const network = new networkModule.default();
+      network.started = true;
+      const nodeA = { id: 'a', name: 'A' };
+      network.nodes = [nodeA];
+      useAppStore.setState({ network, selection: new Set([nodeA]) });
+
+      useAppStore.getState().pushSnapshot();
+
+      await useAppStore.getState().undo();
+
+      // The new network's nodes should be searched for the id
+      const newNetwork = useAppStore.getState().network;
+      expect(newNetwork.parse).toHaveBeenCalled();
+    });
+
+    test('undo marks document as dirty', async () => {
+      const { useAppStore, networkModule } = await loadStore();
+      const network = new networkModule.default();
+      network.started = true;
+      useAppStore.setState({ network, dirty: false });
+
+      useAppStore.getState().pushSnapshot();
+      await useAppStore.getState().undo();
+
+      expect(useAppStore.getState().dirty).toBe(true);
+      expect(window.desktop.setDocumentEdited).toHaveBeenCalledWith(true);
+    });
+
+    test('tabs are preserved across undo when types still exist', async () => {
+      const { useAppStore, networkModule } = await loadStore();
+      const network = new networkModule.default();
+      network.started = true;
+      const myType = { type: 'custom.myShader', name: 'My Shader', source: 'fn main() {}' };
+      network.findNodeType = vi.fn(() => myType);
+      useAppStore.setState({
+        network,
+        tabs: [{ nodeType: myType, modified: true, uncommittedSource: 'edited...' }],
+        activeTabIndex: 0,
+      });
+
+      useAppStore.getState().pushSnapshot();
+
+      // Undo creates a new Network — configure its findNodeType to resolve the type
+      const origCtor = networkModule.default;
+      const CtorSpy = vi.fn(function (...args) {
+        const inst = new origCtor(...args);
+        inst.findNodeType = vi.fn(() => myType);
+        return inst;
+      });
+      // Temporarily patch the constructor used by the store's import
+      // We need to intercept the new Network() call inside undo().
+      // Since the mock module is already in place, we patch the prototype approach won't work.
+      // Instead, let's directly set findNodeType on the resulting network after undo.
+      // A simpler approach: use the mock constructor's default and override after.
+      // Actually, the simplest fix: patch the default mock's findNodeType behavior.
+      // The mock constructor creates fresh mocks each time, so we need a different approach.
+
+      // Workaround: override the mock constructor temporarily
+      const NetworkClass = networkModule.default;
+      const originalProto = NetworkClass.prototype;
+      const origFindNodeType = originalProto.findNodeType;
+
+      // Override at the instance level: after undo, check and re-resolve
+      // Actually let's just test the behavior differently — check that undo
+      // calls findNodeType and that when it returns a value, the tab is kept.
+      // We'll do this by making ALL new Network instances return the type.
+      vi.spyOn(networkModule, 'default').mockImplementation(function (library) {
+        const inst = new NetworkClass(library);
+        inst.findNodeType = vi.fn(() => myType);
+        return inst;
+      });
+
+      await useAppStore.getState().undo();
+
+      // The tab should be preserved (type resolved in new network) but modified state reset
+      const tabs = useAppStore.getState().tabs;
+      expect(tabs).toHaveLength(1);
+      expect(tabs[0].modified).toBe(false);
+      expect(tabs[0].uncommittedSource).toBeNull();
+
+      vi.restoreAllMocks();
+    });
+
+    test('tabs are dropped on undo when type no longer exists', async () => {
+      const { useAppStore, networkModule } = await loadStore();
+      const network = new networkModule.default();
+      network.started = true;
+      const myType = { type: 'custom.myShader', name: 'My Shader' };
+      useAppStore.setState({
+        network,
+        tabs: [{ nodeType: myType, modified: false, uncommittedSource: null }],
+        activeTabIndex: 0,
+      });
+
+      useAppStore.getState().pushSnapshot();
+
+      // After undo, the new network's findNodeType returns undefined (default mock)
+      await useAppStore.getState().undo();
+
+      expect(useAppStore.getState().tabs).toHaveLength(0);
+      expect(useAppStore.getState().activeTabIndex).toBe(-1);
+    });
+
+    test('closeProject clears both undo and redo stacks', async () => {
+      const { useAppStore, networkModule } = await loadStore();
+      const network = new networkModule.default();
+      network.started = true;
+      useAppStore.setState({ network });
+
+      useAppStore.getState().pushSnapshot();
+      useAppStore.getState().pushSnapshot();
+      await useAppStore.getState().undo();
+      expect(useAppStore.getState().undoStack).toHaveLength(1);
+      expect(useAppStore.getState().redoStack).toHaveLength(1);
+
+      useAppStore.getState().closeProject();
+      expect(useAppStore.getState().undoStack).toHaveLength(0);
+      expect(useAppStore.getState().redoStack).toHaveLength(0);
+    });
+
+    test('newProject clears undo/redo stacks', async () => {
+      const { useAppStore, networkModule } = await loadStore();
+      const network = new networkModule.default();
+      network.started = true;
+      useAppStore.setState({ network });
+
+      useAppStore.getState().pushSnapshot();
+      expect(useAppStore.getState().undoStack).toHaveLength(1);
+
+      await useAppStore.getState().newProject();
+      expect(useAppStore.getState().undoStack).toHaveLength(0);
+      expect(useAppStore.getState().redoStack).toHaveLength(0);
+    });
+  });
+
+  // ─── Snapshot instrumentation ────────────────────────────────
+
+  describe('mutating actions push snapshots', () => {
+    async function storeWithNetwork() {
+      const { useAppStore, networkModule } = await loadStore();
+      const network = new networkModule.default();
+      network.started = true;
+      useAppStore.setState({ network });
+      return { useAppStore, network };
+    }
+
+    test('deleteSelection pushes snapshot', async () => {
+      const { useAppStore, network } = await storeWithNetwork();
+      const node = { id: 1 };
+      network.nodes = [node];
+      useAppStore.setState({ selection: new Set([node]) });
+      useAppStore.getState().deleteSelection();
+      expect(useAppStore.getState().undoStack).toHaveLength(1);
+    });
+
+    test('createNode pushes snapshot', async () => {
+      const { useAppStore } = await storeWithNetwork();
+      useAppStore.getState().createNode({ type: 'image.blur' });
+      expect(useAppStore.getState().undoStack).toHaveLength(1);
+    });
+
+    test('connect pushes snapshot', async () => {
+      const { useAppStore } = await storeWithNetwork();
+      useAppStore.getState().connect({ id: 'out1' }, { id: 'in1' });
+      expect(useAppStore.getState().undoStack).toHaveLength(1);
+    });
+
+    test('disconnect pushes snapshot', async () => {
+      const { useAppStore } = await storeWithNetwork();
+      useAppStore.getState().disconnect({ id: 'in1' });
+      expect(useAppStore.getState().undoStack).toHaveLength(1);
+    });
+
+    test('renameNode pushes snapshot', async () => {
+      const { useAppStore } = await storeWithNetwork();
+      useAppStore.getState().renameNode({ id: 1 }, 'New Name');
+      expect(useAppStore.getState().undoStack).toHaveLength(1);
+    });
+
+    test('renameNode with empty name does not push snapshot', async () => {
+      const { useAppStore } = await storeWithNetwork();
+      useAppStore.getState().renameNode({ id: 1 }, '  ');
+      expect(useAppStore.getState().undoStack).toHaveLength(0);
+    });
+
+    test('buildSource pushes snapshot', async () => {
+      const { useAppStore } = await storeWithNetwork();
+      useAppStore.getState().buildSource({ type: 'custom.foo' }, 'new source');
+      expect(useAppStore.getState().undoStack).toHaveLength(1);
+    });
+
+    test('changePortExpression pushes snapshot', async () => {
+      const { useAppStore } = await storeWithNetwork();
+      useAppStore.getState().changePortExpression({ id: 1 }, 'x', 'Math.sin(t)');
+      expect(useAppStore.getState().undoStack).toHaveLength(1);
+    });
+
+    test('togglePortExpression pushes snapshot', async () => {
+      const { useAppStore } = await storeWithNetwork();
+      const node = { id: 1, inPorts: [{ name: 'x', value: 42 }] };
+      useAppStore.getState().togglePortExpression(node, 'x');
+      expect(useAppStore.getState().undoStack).toHaveLength(1);
+    });
+
+    test('deletePortExpression pushes snapshot', async () => {
+      const { useAppStore } = await storeWithNetwork();
+      useAppStore.getState().deletePortExpression({ id: 1 }, 'x');
+      expect(useAppStore.getState().undoStack).toHaveLength(1);
+    });
+
+    test('revertPortValue pushes snapshot', async () => {
+      const { useAppStore } = await storeWithNetwork();
+      const node = { id: 1, inPorts: [{ name: 'x', value: 42, defaultValue: 0 }] };
+      useAppStore.getState().revertPortValue(node, 'x');
+      expect(useAppStore.getState().undoStack).toHaveLength(1);
+    });
+
+    test('forkNodeType pushes snapshot', async () => {
+      const { useAppStore, network } = await storeWithNetwork();
+      const nodeType = { type: 'image.blur', name: 'Blur' };
+      const newNodeType = { type: 'custom.myBlur', name: 'My Blur' };
+      network.forkNodeType = vi.fn(() => newNodeType);
+      useAppStore.getState().forkNodeType(nodeType, 'My Blur', 'custom.myBlur');
+      expect(useAppStore.getState().undoStack).toHaveLength(1);
+    });
+
+    test('changeProjectSetting pushes snapshot and marks dirty', async () => {
+      const { useAppStore } = await storeWithNetwork();
+      useAppStore.getState().changeProjectSetting('width', 1920);
+      expect(useAppStore.getState().undoStack).toHaveLength(1);
+      expect(useAppStore.getState().dirty).toBe(true);
+    });
+  });
+
+  // ─── Port value changes ───────────────────────────────────────
+
+  test('changePortValue does not push snapshots (callers are responsible)', async () => {
+    const { useAppStore, networkModule } = await loadStore();
+    const network = new networkModule.default();
+    network.started = true;
+    useAppStore.setState({ network });
+
+    const node = { id: 1 };
+    useAppStore.getState().changePortValue(node, 'x', 1);
+    useAppStore.getState().changePortValue(node, 'x', 2);
+    useAppStore.getState().changePortValue(node, 'x', 3);
+
+    expect(useAppStore.getState().undoStack).toHaveLength(0);
+    expect(network.setPortValue).toHaveBeenCalledTimes(3);
+    expect(useAppStore.getState().dirty).toBe(true);
+  });
+
   test('renderSequence pauses live playback during export and restores it afterwards', async () => {
     const { useAppStore, networkModule } = await loadStore();
     const network = new networkModule.default();
@@ -222,5 +608,94 @@ describe('useAppStore', () => {
     expect(useAppStore.getState().isPlaying).toBe(true);
     expect(network.beginExport).toHaveBeenCalledTimes(1);
     expect(network.endExport).toHaveBeenCalledTimes(1);
+  });
+
+  // ─── Menu event focus guard ──────────────────────────────────
+
+  describe('handleMenuEvent undo/redo focus guard', () => {
+    function mockActiveElement(tagName, type = undefined) {
+      globalThis.document = globalThis.document || {};
+      Object.defineProperty(globalThis.document, 'activeElement', {
+        value: { tagName, type },
+        configurable: true,
+        writable: true,
+      });
+    }
+
+    // handleMenuEvent fires undo/redo without awaiting, so we flush promises after each call
+    const flush = () => new Promise((r) => setTimeout(r, 0));
+
+    test('undo is blocked when a text input is focused', async () => {
+      const { useAppStore, networkModule } = await loadStore();
+      const network = new networkModule.default();
+      network.started = true;
+      useAppStore.setState({ network });
+
+      useAppStore.getState().pushSnapshot();
+      mockActiveElement('INPUT', 'text');
+      useAppStore.getState().handleMenuEvent('undo', {});
+      await flush();
+
+      expect(useAppStore.getState().undoStack).toHaveLength(1);
+    });
+
+    test('undo is blocked when a textarea is focused', async () => {
+      const { useAppStore, networkModule } = await loadStore();
+      const network = new networkModule.default();
+      network.started = true;
+      useAppStore.setState({ network });
+
+      useAppStore.getState().pushSnapshot();
+      mockActiveElement('TEXTAREA');
+      useAppStore.getState().handleMenuEvent('undo', {});
+      await flush();
+
+      expect(useAppStore.getState().undoStack).toHaveLength(1);
+    });
+
+    test('undo is NOT blocked when a checkbox is focused', async () => {
+      const { useAppStore, networkModule } = await loadStore();
+      const network = new networkModule.default();
+      network.started = true;
+      useAppStore.setState({ network });
+
+      useAppStore.getState().pushSnapshot();
+      mockActiveElement('INPUT', 'checkbox');
+      useAppStore.getState().handleMenuEvent('undo', {});
+      await flush();
+
+      expect(useAppStore.getState().undoStack).toHaveLength(0);
+    });
+
+    test('redo is NOT blocked when a checkbox is focused', async () => {
+      const { useAppStore, networkModule } = await loadStore();
+      const network = new networkModule.default();
+      network.started = true;
+      useAppStore.setState({ network });
+
+      useAppStore.getState().pushSnapshot();
+      await useAppStore.getState().undo();
+      expect(useAppStore.getState().redoStack).toHaveLength(1);
+
+      mockActiveElement('INPUT', 'checkbox');
+      useAppStore.getState().handleMenuEvent('redo', {});
+      await flush();
+
+      expect(useAppStore.getState().redoStack).toHaveLength(0);
+    });
+
+    test('undo works when a non-input element is focused', async () => {
+      const { useAppStore, networkModule } = await loadStore();
+      const network = new networkModule.default();
+      network.started = true;
+      useAppStore.setState({ network });
+
+      useAppStore.getState().pushSnapshot();
+      mockActiveElement('DIV');
+      useAppStore.getState().handleMenuEvent('undo', {});
+      await flush();
+
+      expect(useAppStore.getState().undoStack).toHaveLength(0);
+    });
   });
 });

--- a/src/ui/undo-redo.integration.test.js
+++ b/src/ui/undo-redo.integration.test.js
@@ -1,0 +1,175 @@
+import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
+
+// Integration test: exercises the real Network serialize/parse roundtrip
+// to verify undo/redo captures and restores all port types correctly.
+
+let Network;
+
+const TOGGLE_NODE_SOURCE = `
+const playIn = node.toggleIn('play', true);
+const speedIn = node.numberIn('speed', 1.0);
+node.onStart = () => {};
+node.onFrame = () => {};
+`;
+
+function createMiniLibrary() {
+  return {
+    nodeTypes: [{ type: 'test.toggleNode', name: 'Toggle Node', source: TOGGLE_NODE_SOURCE }],
+    findByType(type) {
+      return this.nodeTypes.find((nt) => nt.type === type);
+    },
+  };
+}
+
+beforeAll(async () => {
+  globalThis.window = globalThis.window || {};
+  globalThis.AudioContext = class AudioContext {};
+  globalThis.GPUTextureUsage = {
+    TEXTURE_BINDING: 1,
+    RENDER_ATTACHMENT: 2,
+    COPY_SRC: 4,
+    COPY_DST: 8,
+  };
+
+  const mod = await import('../model/Network.js');
+  Network = mod.default;
+});
+
+describe('undo/redo serialize roundtrip', () => {
+  let library;
+
+  beforeEach(() => {
+    library = createMiniLibrary();
+  });
+
+  function createNetworkWithToggleNode() {
+    const network = new Network(library);
+    const node = network.createNode('test.toggleNode', 100, 100);
+    return { network, node };
+  }
+
+  function findPort(node, portName) {
+    return node.inPorts.find((p) => p.name === portName);
+  }
+
+  test('toggle port at default value survives serialize → parse roundtrip', () => {
+    const { network, node } = createNetworkWithToggleNode();
+    const playPort = findPort(node, 'play');
+
+    // Toggle is at default (true)
+    expect(playPort.value).toBe(true);
+
+    // Serialize and parse into a new network
+    const snapshot = network.serialize();
+    const restored = new Network(library);
+    restored.parse(snapshot);
+
+    const restoredNode = restored.nodes.find((n) => n.type === 'test.toggleNode');
+    const restoredPort = findPort(restoredNode, 'play');
+    expect(restoredPort.value).toBe(true);
+  });
+
+  test('toggle port changed from default survives serialize → parse roundtrip', () => {
+    const { network, node } = createNetworkWithToggleNode();
+    const playPort = findPort(node, 'play');
+
+    // Change toggle to false (non-default)
+    network.setPortValue(node, 'play', false);
+    expect(playPort.value).toBe(false);
+
+    const snapshot = network.serialize();
+    const restored = new Network(library);
+    restored.parse(snapshot);
+
+    const restoredNode = restored.nodes.find((n) => n.type === 'test.toggleNode');
+    const restoredPort = findPort(restoredNode, 'play');
+    expect(restoredPort.value).toBe(false);
+  });
+
+  test('undo restores toggle port to previous value (true → false → undo → true)', () => {
+    const { network, node } = createNetworkWithToggleNode();
+    const playPort = findPort(node, 'play');
+    expect(playPort.value).toBe(true);
+
+    // Simulate pushSnapshot: capture state BEFORE the change
+    const snapshotBefore = network.serialize();
+
+    // Change toggle to false
+    network.setPortValue(node, 'play', false);
+    expect(playPort.value).toBe(false);
+
+    // Simulate undo: restore from snapshotBefore
+    const restored = new Network(library);
+    restored.parse(snapshotBefore);
+
+    const restoredNode = restored.nodes.find((n) => n.type === 'test.toggleNode');
+    const restoredPort = findPort(restoredNode, 'play');
+    expect(restoredPort.value).toBe(true);
+  });
+
+  test('undo restores number port to previous value', () => {
+    const { network, node } = createNetworkWithToggleNode();
+    const speedPort = findPort(node, 'speed');
+    expect(speedPort.value).toBe(1.0);
+
+    const snapshotBefore = network.serialize();
+
+    network.setPortValue(node, 'speed', 2.5);
+    expect(speedPort.value).toBe(2.5);
+
+    const restored = new Network(library);
+    restored.parse(snapshotBefore);
+
+    const restoredNode = restored.nodes.find((n) => n.type === 'test.toggleNode');
+    const restoredPort = findPort(restoredNode, 'speed');
+    expect(restoredPort.value).toBe(1.0);
+  });
+
+  test('full undo/redo cycle: toggle false → undo → redo', () => {
+    const { network, node } = createNetworkWithToggleNode();
+
+    // Capture initial state (play=true)
+    const snapshot0 = network.serialize();
+
+    // Change play to false
+    network.setPortValue(node, 'play', false);
+    const snapshot1 = network.serialize();
+
+    // UNDO: restore snapshot0 (play should be true)
+    const net1 = new Network(library);
+    net1.parse(snapshot0);
+    const node1 = net1.nodes.find((n) => n.type === 'test.toggleNode');
+    expect(findPort(node1, 'play').value).toBe(true);
+
+    // REDO: restore snapshot1 (play should be false)
+    const net2 = new Network(library);
+    net2.parse(snapshot1);
+    const node2 = net2.nodes.find((n) => n.type === 'test.toggleNode');
+    expect(findPort(node2, 'play').value).toBe(false);
+  });
+
+  test('multiple toggle changes create correct undo chain', () => {
+    const { network, node } = createNetworkWithToggleNode();
+
+    // State 0: play=true (default)
+    const snap0 = network.serialize();
+
+    // State 1: play=false
+    network.setPortValue(node, 'play', false);
+    const snap1 = network.serialize();
+
+    // State 2: play=true again
+    network.setPortValue(node, 'play', true);
+    const snap2 = network.serialize();
+
+    // Undo from state 2 → state 1 (play=false)
+    const net1 = new Network(library);
+    net1.parse(snap1);
+    expect(findPort(net1.nodes[0], 'play').value).toBe(false);
+
+    // Undo from state 1 → state 0 (play=true)
+    const net0 = new Network(library);
+    net0.parse(snap0);
+    expect(findPort(net0.nodes[0], 'play').value).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Merges PR #70 (snapshot-based undo/redo) and fixes all issues found during code review:

- **Undo/redo core**: Snapshot-based using `Network.serialize()`/`parse()`, capturing full network state + selection before each mutation. Supports Cmd+Z / Ctrl+Z (undo) and Cmd+Shift+Z / Ctrl+Y (redo)
- **Stale closure fix**: `NumberDrag` and `StringParam` used `useRef` callbacks that captured the initial `onChange` prop, breaking parameter editing after undo. Fixed with ref-sync pattern
- **Checkbox undo fix**: Focus guard blocked undo for ALL `<input>` elements including checkboxes. Now only blocks text-editable inputs
- **Snapshot-per-commit**: Replaced 500ms throttle with component-driven snapshot timing — one undo entry per gesture (drag start, picker open, discrete click)
- **Race condition guard**: `_undoInProgress` flag prevents interleaved async undo/redo calls
- **Tab preservation**: Tabs re-resolve against new network on undo/redo instead of being force-closed
- **Boolean port serialization**: `PORT_TYPE_BOOLEAN` now included in `serialize()` for correct undo snapshots
- **No-op drag snapshots**: Deferred to first actual mouse movement
- **Double-fire prevention**: Removed duplicate keyboard handlers from App.jsx

## Test plan

- [x] 82 tests pass (`npm test`) — 37 store unit tests, 6 integration tests, 39 existing
- [x] Integration tests exercise real `Network.serialize()`/`parse()` roundtrip for toggle ports
- [x] Focus guard tests verify checkbox undo works while text input undo is still deferred
- [x] Build succeeds (`npm run build`)
- [x] Manual: toggle a checkbox, Cmd+Z restores it
- [x] Manual: drag a number slider, Cmd+Z undoes the entire drag as one step
- [x] Manual: undo after undo (rapid Cmd+Z) doesn't skip or corrupt state

🤖 Generated with [Claude Code](https://claude.com/claude-code)