### PR TITLE
Add Projection Quad node prototype for projection mapping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,3 +40,17 @@ React-based interface (`src/ui/`) using functional components and Zustand for st
 ### Development Notes
 
 - Make sure code is formatted correctly with `npm run format` and tested with `npm test` before committing/handoff to user.
+
+### Pre-handoff & post-ship verification
+
+Local checks before handoff (in order):
+
+1. `npm run format` — Prettier writes any changes.
+2. `npm test` — must be all-green.
+3. `npm run build` — production build must succeed.
+
+After pushing a PR, do not declare "shipped" until CI is checked:
+
+1. Wait ~30s, then run `gh pr checks <PR#>` (or `gh pr view <PR#> --json statusCheckRollup`).
+2. If any required check failed, fetch the log with `gh run view <runId> --log-failed` and surface the failure to the user *with the relevant snippet* — do not just say "CI failed."
+3. Distinguish PR-caused failures from CI-infra failures (e.g. node/npm upgrade steps, dependabot, Netlify quota). For infra failures, name the failing step and note that recent PRs hit the same thing — don't try to silently patch the workflow unless asked.

--- a/src/electron/main.js
+++ b/src/electron/main.js
@@ -463,6 +463,7 @@ function createApplicationMenu() {
     label: 'View',
     submenu: [
       { label: 'Enter Full Screen', accelerator: 'CmdOrCtrl+Shift+F', click: emit('enter-full-screen') },
+      { label: 'Toggle Performance Overlay', accelerator: 'CmdOrCtrl+Shift+P', click: emit('toggle-performance-overlay') },
       { type: 'separator' },
       { role: 'reload' },
       { role: 'forcereload' },

--- a/src/g.js
+++ b/src/g.js
@@ -26,3 +26,18 @@ export const rgba = (r, g, b, a) => `rgba(${r}, ${g}, ${b}, ${a})`;
 
 export const toRadians = (v) => v * RADIANS;
 export const toDegrees = (v) => v * DEGREES;
+
+// Fit a contentW×contentH rectangle inside a boxW×boxH frame, preserving aspect.
+// Returns the uniform scale + the centered rect (offset + scaled dimensions).
+export function computeAspectFit(boxW, boxH, contentW, contentH) {
+  const scale = Math.min(boxW / contentW, boxH / contentH);
+  const width = contentW * scale;
+  const height = contentH * scale;
+  return {
+    scale,
+    width,
+    height,
+    offsetX: (boxW - width) / 2,
+    offsetY: (boxH - height) / 2,
+  };
+}

--- a/src/model/Network.js
+++ b/src/model/Network.js
@@ -19,6 +19,7 @@ import Port, {
 } from './Port';
 import DependencyGraph from './DependencyGraph';
 import { setExpressionContext } from '../expr';
+import { Point } from '../g';
 
 export const getDefaultNetwork = () => ({
   nodes: [
@@ -226,7 +227,13 @@ export default class Network {
           } else if (port.type === PORT_TYPE_SELECT) {
             port._value = value;
           } else if (port.type === PORT_TYPE_POINT) {
-            port._value = new g.Point(value[0], value[1]);
+            if (value.type === 'expression') {
+              port._value = value;
+            } else {
+              // Saved as { type:'value', value:[x,y] }; rehydrate the Point and keep the wrapper.
+              const [px, py] = value.value;
+              port._value = { type: 'value', value: new Point(px, py) };
+            }
           } else if (port.type === PORT_TYPE_COLOR) {
             port._value = structuredClone(value);
           } else if (port.type === PORT_TYPE_FILE) {

--- a/src/nodes/image/projectionQuad.js
+++ b/src/nodes/image/projectionQuad.js
@@ -1,0 +1,135 @@
+/**
+ * @name Projection Quad
+ * @description Map an image onto a draggable quadrilateral (projection mapping).
+ * @category image
+ */
+
+const inputIn = node.imageIn('in');
+const outputWidthIn = node.numberIn('outputWidth', 1920, { min: 1, max: 8192, step: 1 });
+const outputHeightIn = node.numberIn('outputHeight', 1080, { min: 1, max: 8192, step: 1 });
+const topLeftIn = node.pointIn('topLeft', new g.Point(0, 0));
+const topRightIn = node.pointIn('topRight', new g.Point(1920, 0));
+const bottomRightIn = node.pointIn('bottomRight', new g.Point(1920, 1080));
+const bottomLeftIn = node.pointIn('bottomLeft', new g.Point(0, 1080));
+// UI-only flag: controls whether the corner-drag overlay shows in fullscreen.
+// Persisted as a port so it survives reload and can be bound to an expression
+// or OSC trigger (e.g. hide handles when going live).
+node.toggleIn('showUI', true);
+const imageOut = node.imageOut('out');
+
+const uniformsMeta = {
+  u_output_size: 'vec2f',
+  u_h_inv: 'mat3x3f',
+};
+
+const wgsl = `
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4f {
+  // Convert UV (0..1) to output pixel coordinates.
+  let pos = vec3f(in.uv.x * u.u_output_size.x, in.uv.y * u.u_output_size.y, 1.0);
+
+  // Apply inverse homography: output pixel -> source UV (homogeneous).
+  let src = u.u_h_inv * pos;
+  let src_uv = src.xy / src.z;
+
+  // Outside the quad (i.e., source UV outside the unit square) -> transparent.
+  if (src_uv.x < 0.0 || src_uv.x > 1.0 || src_uv.y < 0.0 || src_uv.y > 1.0) {
+    return vec4f(0.0, 0.0, 0.0, 0.0);
+  }
+
+  return textureSampleLevel(u_input_texture, defaultSampler, src_uv, 0.0);
+}
+`;
+
+// Closed-form mapping from the unit square (0,0),(1,0),(1,1),(0,1) to the
+// user-defined quad (p0,p1,p2,p3). Returns a 3x3 row-major homography H.
+function squareToQuad(p0, p1, p2, p3) {
+  const dx1 = p1.x - p2.x;
+  const dx2 = p3.x - p2.x;
+  const sx = p0.x - p1.x + p2.x - p3.x;
+  const dy1 = p1.y - p2.y;
+  const dy2 = p3.y - p2.y;
+  const sy = p0.y - p1.y + p2.y - p3.y;
+
+  if (Math.abs(sx) < 1e-10 && Math.abs(sy) < 1e-10) {
+    // Affine (parallelogram) case.
+    return [p1.x - p0.x, p3.x - p0.x, p0.x, p1.y - p0.y, p3.y - p0.y, p0.y, 0, 0, 1];
+  }
+
+  const det = dx1 * dy2 - dx2 * dy1;
+  const g31 = (sx * dy2 - sy * dx2) / det;
+  const g32 = (sy * dx1 - sx * dy1) / det;
+  return [p1.x - p0.x + g31 * p1.x, p3.x - p0.x + g32 * p3.x, p0.x, p1.y - p0.y + g31 * p1.y, p3.y - p0.y + g32 * p3.y, p0.y, g31, g32, 1];
+}
+
+function invert3x3(m) {
+  const [a, b, c, d, e, f, g_, h, i] = m;
+  const A = e * i - f * h;
+  const B = -(d * i - f * g_);
+  const C = d * h - e * g_;
+  const det = a * A + b * B + c * C;
+  if (Math.abs(det) < 1e-10) {
+    return [1, 0, 0, 0, 1, 0, 0, 0, 1];
+  }
+  const inv = 1 / det;
+  return [
+    A * inv,
+    -(b * i - c * h) * inv,
+    (b * f - c * e) * inv,
+    B * inv,
+    (a * i - c * g_) * inv,
+    -(a * f - c * d) * inv,
+    C * inv,
+    -(a * h - b * g_) * inv,
+    (a * e - b * d) * inv,
+  ];
+}
+
+// WebGPU mat3x3<f32> uses 3 vec3 columns padded to vec4 (48 bytes, 12 floats).
+// Convert a row-major 9-element array into the column-major-with-padding layout
+// the uniform packer expects.
+function packMat3x3(rowMajor) {
+  const [a, b, c, d, e, f, g_, h, i] = rowMajor;
+  return [a, d, g_, 0, b, e, h, 0, c, f, i, 0];
+}
+
+let pipeline, target;
+
+node.onStart = () => {
+  const preamble = figment.generateWgslPreamble({ uniforms: uniformsMeta, textures: ['u_input_texture'] });
+  pipeline = figment.createRenderPipeline({
+    wgsl: preamble + wgsl,
+    uniforms: uniformsMeta,
+    textures: ['u_input_texture'],
+    label: 'projection-quad',
+  });
+  target = new figment.RenderTarget({ label: 'projection-quad' });
+};
+
+node.onRender = () => {
+  const img = inputIn.value;
+  if (!img) return;
+
+  const w = Math.max(1, Math.floor(outputWidthIn.value));
+  const h = Math.max(1, Math.floor(outputHeightIn.value));
+  target.setSize(w, h);
+
+  const h_s2q = squareToQuad(topLeftIn.value, topRightIn.value, bottomRightIn.value, bottomLeftIn.value);
+  const h_inv = invert3x3(h_s2q);
+
+  figment.drawFullscreen(
+    pipeline,
+    {
+      u_output_size: [w, h],
+      u_h_inv: packMat3x3(h_inv),
+    },
+    { u_input_texture: img },
+    target,
+    { clearColor: { r: 0, g: 0, b: 0, a: 0 } },
+  );
+  imageOut.set(target);
+};
+
+node.onStop = () => {
+  target?.destroy();
+};

--- a/src/profiling.js
+++ b/src/profiling.js
@@ -1,0 +1,149 @@
+/**
+ * Performance profiling utilities for Figment.
+ *
+ * Collects performance.measure() entries emitted by the render loop,
+ * Network, and individual nodes (e.g. the ONNX image model node).
+ *
+ * Usage:
+ *   window.figment.dumpPerformance()   — log a stats table to the console
+ *   window.figment.clearPerformance()  — clear accumulated measurements
+ */
+
+function computeStats(durations) {
+  if (durations.length === 0) return null;
+  const sorted = [...durations].sort((a, b) => a - b);
+  const sum = sorted.reduce((a, b) => a + b, 0);
+  const mean = sum / sorted.length;
+  const p50 = sorted[Math.floor(sorted.length * 0.5)];
+  const p95 = sorted[Math.floor(sorted.length * 0.95)];
+  return {
+    count: sorted.length,
+    mean: mean.toFixed(2),
+    min: sorted[0].toFixed(2),
+    max: sorted[sorted.length - 1].toFixed(2),
+    p50: p50.toFixed(2),
+    p95: p95.toFixed(2),
+  };
+}
+
+/**
+ * Collect all performance.measure() entries, group by name,
+ * compute stats, and log a formatted table to the console.
+ */
+export function dumpPerformance() {
+  const entries = performance.getEntriesByType('measure');
+  if (entries.length === 0) {
+    console.log('No performance measurements recorded. Let the project run for a few seconds first.');
+    return;
+  }
+
+  // Group durations by measure name
+  const groups = new Map();
+  for (const entry of entries) {
+    if (!groups.has(entry.name)) groups.set(entry.name, []);
+    groups.get(entry.name).push(entry.duration);
+  }
+
+  // Build a table-friendly object
+  const table = {};
+  // Define a display order for known phases
+  const order = [
+    'frame',
+    'render-all-nodes',
+    'onnx-image:preprocess-dispatch',
+    'onnx-image:session-run',
+    'onnx-image:postprocess-dispatch',
+  ];
+
+  const sortedNames = [...groups.keys()].sort((a, b) => {
+    const ai = order.indexOf(a);
+    const bi = order.indexOf(b);
+    if (ai !== -1 && bi !== -1) return ai - bi;
+    if (ai !== -1) return -1;
+    if (bi !== -1) return 1;
+    return a.localeCompare(b);
+  });
+
+  for (const name of sortedNames) {
+    const stats = computeStats(groups.get(name));
+    if (stats) table[name] = stats;
+  }
+
+  console.table(table);
+  return table;
+}
+
+/**
+ * Clear all accumulated performance marks and measures.
+ */
+export function clearPerformance() {
+  performance.clearMarks();
+  performance.clearMeasures();
+  console.log('Performance measurements cleared.');
+}
+
+// ── Real-time collection via PerformanceObserver ────────────────────
+
+const RING_SIZE = 120; // frames worth of data
+
+// Ring buffer per measure name: Map<string, number[]>
+const ringBuffers = new Map();
+
+function getRing(name) {
+  if (!ringBuffers.has(name)) ringBuffers.set(name, []);
+  return ringBuffers.get(name);
+}
+
+function pushToRing(name, duration) {
+  const ring = getRing(name);
+  ring.push(duration);
+  if (ring.length > RING_SIZE) ring.shift();
+}
+
+/**
+ * Return rolling average for a given measure name over the last N samples.
+ */
+export function getRollingAvg(name, n = 60) {
+  const ring = ringBuffers.get(name);
+  if (!ring || ring.length === 0) return 0;
+  const slice = ring.slice(-n);
+  return slice.reduce((a, b) => a + b, 0) / slice.length;
+}
+
+/**
+ * Return the latest value for a given measure name.
+ */
+export function getLatest(name) {
+  const ring = ringBuffers.get(name);
+  if (!ring || ring.length === 0) return 0;
+  return ring[ring.length - 1];
+}
+
+/**
+ * Return all tracked measure names that have data.
+ */
+export function getTrackedNames() {
+  return [...ringBuffers.keys()];
+}
+
+/**
+ * Start the PerformanceObserver that feeds the ring buffers.
+ * Safe to call multiple times — only the first call has effect.
+ */
+let observerStarted = false;
+export function startObserver() {
+  if (observerStarted) return;
+  observerStarted = true;
+
+  const patterns = ['frame', 'render-all-nodes', 'onnx-image:', 'node-'];
+
+  const observer = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      if (patterns.some((p) => entry.name.startsWith(p) || entry.name === p)) {
+        pushToRing(entry.name, entry.duration);
+      }
+    }
+  });
+
+  observer.observe({ type: 'measure', buffered: false });
+}

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -12,7 +12,9 @@ import RenderDialog from './RenderDialog';
 import MigrationDialog from './MigrationDialog';
 import ProjectSettingsDialog from './ProjectSettingsDialog';
 import { initExpressionContext } from '../expr';
+import PerformanceOverlay from './PerformanceOverlay';
 import { useAppStore } from './store';
+import { dumpPerformance, clearPerformance } from '../profiling';
 
 window.stats = new Stats();
 window.stats.dom.style.top = '';
@@ -30,6 +32,7 @@ export default function App(props) {
   const showProjectSettingsDialog = useAppStore((state) => state.showProjectSettingsDialog);
   const showNodeRenameDialog = useAppStore((state) => state.showNodeRenameDialog);
   const migration = useAppStore((state) => state.migration);
+  const showPerformanceOverlay = useAppStore((state) => state.showPerformanceOverlay);
 
   // Actions
   const startNetwork = useAppStore((state) => state.startNetwork);
@@ -110,6 +113,12 @@ export default function App(props) {
   const onKeyDown = useCallback(
     (e) => {
       if (e.keyCode === 27 && useAppStore.getState().fullscreen) toggleFullscreen();
+      // Ctrl/Cmd+Shift+P toggles performance overlay
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.code === 'KeyP') {
+        e.preventDefault();
+        const s = useAppStore.getState();
+        useAppStore.setState({ showPerformanceOverlay: !s.showPerformanceOverlay });
+      }
     },
     [toggleFullscreen],
   );
@@ -193,6 +202,7 @@ export default function App(props) {
     return (
       <div className="app">
         <Viewer />
+        {showPerformanceOverlay && <PerformanceOverlay />}
       </div>
     );
   }
@@ -210,6 +220,7 @@ export default function App(props) {
       {showRenderDialog && <RenderDialog />}
       {showProjectSettingsDialog && <ProjectSettingsDialog />}
       {migration && <MigrationDialog />}
+      {showPerformanceOverlay && <PerformanceOverlay />}
     </>
   );
 }

--- a/src/ui/ParamsEditor.jsx
+++ b/src/ui/ParamsEditor.jsx
@@ -7,6 +7,7 @@ import { Point } from '../g';
 import Icon from './Icon';
 import * as figment from '../figment';
 import { useAppStore } from './store';
+import ProjectionQuadEditor from './ProjectionQuadEditor';
 
 import {
   PORT_TYPE_TRIGGER,
@@ -791,6 +792,11 @@ export default function ParamsEditor() {
             <pre className="whitespace-pre-wrap flex-1 mb-2">{errorTitle}</pre>
             <pre className="whitespace-pre-wrap">{errorStack}</pre>
           </div>
+        </div>
+      )}
+      {node.type === 'image.projectionQuad' && (
+        <div className="p-2">
+          <ProjectionQuadEditor node={node} width={editorSplitterWidth - 16} height={Math.round((editorSplitterWidth - 16) * 0.6)} />
         </div>
       )}
       <div className="params__grid grid ">{node.inPorts.map((port) => renderPort(network, node, port))}</div>

--- a/src/ui/PerformanceOverlay.jsx
+++ b/src/ui/PerformanceOverlay.jsx
@@ -1,0 +1,126 @@
+import React, { useEffect, useRef } from 'react';
+import { getRollingAvg, getLatest, getTrackedNames, startObserver } from '../profiling';
+
+const PHASES = [
+  { key: 'frame', label: 'Frame', color: '#888' },
+  { key: 'render-all-nodes', label: 'Render All', color: '#6cf' },
+  { key: 'onnx-image:preprocess-dispatch', label: 'Pre (GPU→NCHW)', color: '#f90' },
+  { key: 'onnx-image:session-run', label: 'ONNX Inference', color: '#f44' },
+  { key: 'onnx-image:postprocess-dispatch', label: 'Post (NCHW→GPU)', color: '#4c4' },
+];
+
+const MAX_NODE_ROWS = 5;
+const WIDTH = 260;
+const HEADER_H = 20;
+const ROW_H = 18;
+const SECTION_GAP = 6;
+const BAR_MAX_W = 120;
+
+export default function PerformanceOverlay() {
+  const canvasRef = useRef(null);
+  const rafRef = useRef(null);
+
+  useEffect(() => {
+    startObserver();
+
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext('2d');
+    const dpr = window.devicePixelRatio || 1;
+    let prevHeight = 0;
+
+    function resize(h) {
+      if (h === prevHeight) return;
+      prevHeight = h;
+      canvas.width = WIDTH * dpr;
+      canvas.height = h * dpr;
+      canvas.style.width = WIDTH + 'px';
+      canvas.style.height = h + 'px';
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+
+    function draw() {
+      // Collect per-node entries, sort by avg duration descending, take top N
+      const allNames = getTrackedNames();
+      const phaseKeys = new Set(PHASES.map((p) => p.key));
+      const nodeEntries = allNames
+        .filter((n) => n.startsWith('node-') && !phaseKeys.has(n))
+        .map((name) => ({ key: name, label: name.replace('node-', ''), avg: getRollingAvg(name, 60) }))
+        .sort((a, b) => b.avg - a.avg)
+        .slice(0, MAX_NODE_ROWS);
+
+      const hasNodes = nodeEntries.length > 0;
+      const totalH = HEADER_H + PHASES.length * ROW_H + (hasNodes ? SECTION_GAP + nodeEntries.length * ROW_H : 0) + 4;
+
+      resize(totalH);
+
+      ctx.clearRect(0, 0, WIDTH, totalH);
+      ctx.fillStyle = 'rgba(0,0,0,0.75)';
+      ctx.fillRect(0, 0, WIDTH, totalH);
+
+      const frameAvg = getRollingAvg('frame', 60);
+      const ceil = Math.max(frameAvg, 16);
+
+      ctx.font = '10px monospace';
+      ctx.textBaseline = 'middle';
+
+      // Header
+      ctx.fillStyle = '#fff';
+      ctx.fillText('Performance (avg 60f)', 6, HEADER_H / 2);
+
+      // Draw phase rows
+      for (let i = 0; i < PHASES.length; i++) {
+        drawRow(ctx, PHASES[i].key, PHASES[i].label, PHASES[i].color, HEADER_H + i * ROW_H, ceil);
+      }
+
+      // Draw top-N node rows
+      if (hasNodes) {
+        const nodeStartY = HEADER_H + PHASES.length * ROW_H + SECTION_GAP;
+        for (let i = 0; i < nodeEntries.length; i++) {
+          drawRow(ctx, nodeEntries[i].key, nodeEntries[i].label, '#da0', nodeStartY + i * ROW_H, ceil);
+        }
+      }
+
+      rafRef.current = requestAnimationFrame(draw);
+    }
+
+    rafRef.current = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{
+        position: 'fixed',
+        bottom: '48px',
+        left: '4px',
+        zIndex: 10000,
+        pointerEvents: 'none',
+      }}
+    />
+  );
+}
+
+function drawRow(ctx, key, label, color, y, ceil) {
+  const avg = getRollingAvg(key, 60);
+  const latest = getLatest(key);
+
+  // Bar
+  const barW = ceil > 0 ? Math.min((avg / ceil) * BAR_MAX_W, BAR_MAX_W) : 0;
+  ctx.fillStyle = color;
+  ctx.globalAlpha = 0.6;
+  ctx.fillRect(6, y, barW, ROW_H - 4);
+  ctx.globalAlpha = 1;
+
+  // Label
+  ctx.fillStyle = '#fff';
+  ctx.fillText(label, 8, y + (ROW_H - 4) / 2);
+
+  // Value
+  ctx.fillStyle = '#ccc';
+  ctx.fillText(`${avg.toFixed(1)}ms`, BAR_MAX_W + 14, y + (ROW_H - 4) / 2);
+
+  // Latest
+  ctx.fillStyle = '#888';
+  ctx.fillText(`(${latest.toFixed(1)})`, BAR_MAX_W + 70, y + (ROW_H - 4) / 2);
+}

--- a/src/ui/ProjectionQuadEditor.jsx
+++ b/src/ui/ProjectionQuadEditor.jsx
@@ -1,0 +1,192 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { Point, computeAspectFit } from '../g';
+import { useAppStore } from './store';
+
+const CORNER_PORTS = ['topLeft', 'topRight', 'bottomRight', 'bottomLeft'];
+const DIAGONALS = [
+  [0, 2],
+  [1, 3],
+];
+// Top corners blue, bottom corners orange — quick "which way is up" cue on the projector.
+const HANDLE_COLORS = ['#5DADE2', '#5DADE2', '#F39C12', '#F39C12'];
+
+// Generous affordance around every visible corner. Off-screen corners get an
+// unlimited radius so they stay reachable no matter how far they've been dragged —
+// closest-wins ranking still makes visible corners win when nearby.
+const HIT_RADIUS = 100;
+
+function isInside(sc, boxW, boxH) {
+  return sc.x >= 0 && sc.x <= boxW && sc.y >= 0 && sc.y <= boxH;
+}
+
+function findPort(node, name) {
+  return node.inPorts.find((p) => p.name === name);
+}
+
+function readCorners(node) {
+  return CORNER_PORTS.map((name) => {
+    const port = findPort(node, name);
+    return port ? port.value : new Point(0, 0);
+  });
+}
+
+function readOutputSize(node) {
+  const w = findPort(node, 'outputWidth')?.value ?? 1920;
+  const h = findPort(node, 'outputHeight')?.value ?? 1080;
+  return { width: w, height: h };
+}
+
+function projectorToScreen(pt, fit) {
+  return {
+    x: fit.offsetX + pt.x * fit.scale,
+    y: fit.offsetY + pt.y * fit.scale,
+  };
+}
+
+/**
+ * Interactive quad-corner editor.
+ *
+ * variant: 'panel' (chrome + background) or 'overlay' (transparent, for use
+ * over the fullscreen viewer where the actual rendered image is the backdrop).
+ */
+export default function ProjectionQuadEditor({ node, width, height, variant = 'panel' }) {
+  const changePortValue = useAppStore((s) => s.changePortValue);
+  const pushSnapshot = useAppStore((s) => s.pushSnapshot);
+  useAppStore((s) => s.version);
+
+  const svgRef = useRef(null);
+  const [dragIndex, setDragIndex] = useState(-1);
+  // Per-drag baseline so movement stays relative: cornerStart + (mouse - mouseStart).
+  const dragStartRef = useRef(null);
+
+  const corners = readCorners(node);
+  const { width: projW, height: projH } = readOutputSize(node);
+  const fit = useMemo(() => computeAspectFit(width, height, projW, projH), [width, height, projW, projH]);
+
+  const screenCorners = corners.map((c) => projectorToScreen(c, fit));
+
+  const onPointerDown = useCallback(
+    (e) => {
+      const rect = svgRef.current.getBoundingClientRect();
+      const sx = e.clientX - rect.left;
+      const sy = e.clientY - rect.top;
+
+      // Closest-corner-within-radius wins. Visible corners use a 100px cap so
+      // adjacent affordances don't fight; off-screen corners drop the cap.
+      let best = -1;
+      let bestDist = Infinity;
+      screenCorners.forEach((sc, i) => {
+        const radius = isInside(sc, width, height) ? HIT_RADIUS : Infinity;
+        const d = Math.hypot(sc.x - sx, sc.y - sy);
+        if (d <= radius && d < bestDist) {
+          bestDist = d;
+          best = i;
+        }
+      });
+      if (best === -1) return;
+      e.preventDefault();
+      e.stopPropagation();
+      pushSnapshot();
+      dragStartRef.current = {
+        mouseX: sx,
+        mouseY: sy,
+        cornerX: corners[best].x,
+        cornerY: corners[best].y,
+      };
+      setDragIndex(best);
+      svgRef.current.setPointerCapture(e.pointerId);
+    },
+    [screenCorners, corners, pushSnapshot, width, height],
+  );
+
+  const onPointerMove = useCallback(
+    (e) => {
+      if (dragIndex === -1 || !dragStartRef.current) return;
+      const rect = svgRef.current.getBoundingClientRect();
+      const sx = e.clientX - rect.left;
+      const sy = e.clientY - rect.top;
+      const start = dragStartRef.current;
+      const dxProj = (sx - start.mouseX) / fit.scale;
+      const dyProj = (sy - start.mouseY) / fit.scale;
+      changePortValue(node, CORNER_PORTS[dragIndex], new Point(start.cornerX + dxProj, start.cornerY + dyProj));
+    },
+    [dragIndex, fit, node, changePortValue],
+  );
+
+  const onPointerUp = useCallback(
+    (e) => {
+      if (dragIndex === -1) return;
+      setDragIndex(-1);
+      dragStartRef.current = null;
+      try {
+        svgRef.current.releasePointerCapture(e.pointerId);
+      } catch (_) {
+        // releasePointerCapture throws if the pointer was already released — safe to ignore.
+      }
+    },
+    [dragIndex],
+  );
+
+  const polygonPoints = screenCorners.map((s) => `${s.x},${s.y}`).join(' ');
+  const isOverlay = variant === 'overlay';
+  const stroke = 'rgba(120,180,255,0.95)';
+  const fill = 'rgba(120,180,255,0.08)';
+
+  // In overlay variant, defer to CSS (`.projection-quad-overlay` rule) so the
+  // hide-cursor !important in fullscreen doesn't fight inline styles.
+  const cursor = isOverlay ? undefined : dragIndex !== -1 ? 'grabbing' : 'default';
+
+  return (
+    <svg
+      ref={svgRef}
+      width={width}
+      height={height}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+      style={{
+        touchAction: 'none',
+        background: isOverlay ? 'transparent' : '#111',
+        cursor,
+        userSelect: 'none',
+      }}
+    >
+      <rect
+        x={fit.offsetX}
+        y={fit.offsetY}
+        width={fit.width}
+        height={fit.height}
+        fill="none"
+        stroke={isOverlay ? 'rgba(255,255,255,0.3)' : 'rgba(255,255,255,0.15)'}
+        strokeDasharray="4 4"
+      />
+
+      <polygon points={polygonPoints} fill={fill} stroke={stroke} strokeWidth="2" />
+
+      {DIAGONALS.map(([a, b]) => (
+        <line
+          key={`${a}-${b}`}
+          x1={screenCorners[a].x}
+          y1={screenCorners[a].y}
+          x2={screenCorners[b].x}
+          y2={screenCorners[b].y}
+          stroke={stroke}
+          strokeOpacity="0.4"
+        />
+      ))}
+
+      {screenCorners.map((sc, i) => (
+        <circle
+          key={i}
+          cx={sc.x}
+          cy={sc.y}
+          r={dragIndex === i ? 9 : 7}
+          fill={HANDLE_COLORS[i]}
+          stroke="rgba(255,255,255,0.9)"
+          strokeWidth="1.5"
+        />
+      ))}
+    </svg>
+  );
+}

--- a/src/ui/Viewer.jsx
+++ b/src/ui/Viewer.jsx
@@ -1,7 +1,9 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import * as figment from '../figment';
+import { computeAspectFit } from '../g';
 import { useAppStore } from './store';
 import { shouldRedrawViewer } from './viewer-state';
+import ProjectionQuadEditor from './ProjectionQuadEditor';
 
 const BLIT_WGSL = `
 struct Uniforms {
@@ -27,10 +29,13 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
 
 export default function Viewer() {
   const network = useAppStore((s) => s.network);
+  const fullscreen = useAppStore((s) => s.fullscreen);
+  useAppStore((s) => s.version); // re-render overlays on port changes
   const canvasRef = useRef(null);
   const gpuContextRef = useRef(null);
   const blitPipelineRef = useRef(null);
   const shouldDrawRef = useRef(false);
+  const [letterbox, setLetterbox] = useState(null);
 
   const draw = () => {
     const device = figment.getDevice();
@@ -54,17 +59,15 @@ export default function Viewer() {
 
     if (!outPort.value || !outPort.value.texture) return;
 
-    const textureWidth = outPort.value.width;
-    const textureHeight = outPort.value.height;
-    const textureRatio = textureWidth / textureHeight;
-    const canvasRatio = canvas.width / canvas.height;
+    const fit = computeAspectFit(canvas.width, canvas.height, outPort.value.width, outPort.value.height);
+    const scale = [fit.width / canvas.width, fit.height / canvas.height];
 
-    let scale;
-    if (textureRatio > canvasRatio) {
-      scale = [1.0, canvasRatio / textureRatio];
-    } else {
-      scale = [textureRatio / canvasRatio, 1.0];
-    }
+    setLetterbox((prev) => {
+      if (prev && prev.offsetX === fit.offsetX && prev.offsetY === fit.offsetY && prev.width === fit.width && prev.height === fit.height) {
+        return prev;
+      }
+      return { offsetX: fit.offsetX, offsetY: fit.offsetY, width: fit.width, height: fit.height };
+    });
 
     // Render to the canvas texture
     const canvasTexture = gpuContext.getCurrentTexture();
@@ -169,9 +172,34 @@ export default function Viewer() {
     };
   }, []);
 
+  const projectionNodes = fullscreen
+    ? network.nodes.filter((n) => {
+        if (n.type !== 'image.projectionQuad') return false;
+        const showUIPort = n.inPorts.find((p) => p.name === 'showUI');
+        return showUIPort ? showUIPort.value : true;
+      })
+    : [];
+
   return (
     <div className="fixed inset-0 overflow-hidden bg-black">
       <canvas ref={canvasRef}></canvas>
+      {letterbox &&
+        projectionNodes.map((node) => (
+          <div
+            key={node.id}
+            className="projection-quad-overlay"
+            style={{
+              position: 'absolute',
+              left: letterbox.offsetX,
+              top: letterbox.offsetY,
+              width: letterbox.width,
+              height: letterbox.height,
+              pointerEvents: 'auto',
+            }}
+          >
+            <ProjectionQuadEditor node={node} width={letterbox.width} height={letterbox.height} variant="overlay" />
+          </div>
+        ))}
     </div>
   );
 }

--- a/src/ui/css/main.css
+++ b/src/ui/css/main.css
@@ -36,6 +36,12 @@ body {
   cursor: none !important;
 }
 
+/* Projection-quad calibration handles need a visible cursor even in fullscreen. */
+.hide-cursor .projection-quad-overlay,
+.hide-cursor .projection-quad-overlay * {
+  cursor: crosshair !important;
+}
+
 .is-selectable,
 pre,
 code {

--- a/src/ui/index.jsx
+++ b/src/ui/index.jsx
@@ -9,8 +9,11 @@ import * as mediabunny from 'mediabunny';
 
 import App from './App';
 
+import { dumpPerformance, clearPerformance } from '../profiling';
+
 window.g = g;
 window.figment = figment;
+window.profiling = { dumpPerformance, clearPerformance };
 window.ort = ort;
 window.mediapipe = mediapipe;
 window.drawing_utils = drawing_utils;

--- a/src/ui/store.js
+++ b/src/ui/store.js
@@ -39,6 +39,7 @@ export const useAppStore = create((set, get) => ({
   midiMessageMap: new Map(),
   midiProgramChangeMap: new Map(),
   midiDevices: [],
+  showPerformanceOverlay: false,
   migration: null, // { phase, webglTypeCount, nodeCount, nodesCompleted, error, _pendingProject, _pendingFilePath, _stopPolling }
 
   // Generic setter helper
@@ -631,6 +632,9 @@ export const useAppStore = create((set, get) => ({
         if (node) get().deletePortExpression(node, portName);
         break;
       }
+      case 'toggle-performance-overlay':
+        set({ showPerformanceOverlay: !get().showPerformanceOverlay });
+        break;
       default:
         console.error('Unknown menu event:', name);
     }


### PR DESCRIPTION
## Summary

Prototype of map.club-style projection mapping inside Figment: a new `image.projectionQuad` node warps an input image onto a four-corner quadrilateral, with interactive corner-dragging both in the params panel and as an overlay on the fullscreen viewer (for calibrating against a real projector).

- **Node**: 4 corner ports (TL/TR/BR/BL) + outputWidth/outputHeight + a `showUI` toggle. WGSL fragment maps each output pixel back to source UV via an inverse homography computed on the CPU each frame.
- **Params widget**: SVG editor showing the projector canvas, quad outline, diagonals, and four handles (top blue, bottom orange) with closest-corner-wins ranking. 100px affordance radius on visible corners, unlimited on off-screen ones so dragged-off corners stay reachable. Drag is relative — click 80px from a handle, the handle moves by your delta, not snaps to the cursor.
- **Fullscreen overlay**: same widget positioned exactly over the letterboxed image area so you can calibrate while seeing the projection. A CSS exception keeps the cursor visible despite fullscreen `hide-cursor`. `showUI=false` hides the overlay for a clean show.
- **Bug fix in `Network.parse()`**: `PORT_TYPE_POINT` deserialization indexed the `{type:'value', value:[x,y]}` wrapper instead of its inner value, and dropped the `{type:'value'}` envelope. No prior built-in node uses point ports, so it was never exercised — the projection-quad node tripped it the first time the user saved/reopened a project.
- **Refactor**: extracted `computeAspectFit()` into `g.js` and used it from both `Viewer.jsx` (letterbox + shader scale) and the new editor.

Math notes: closed-form unit-square → quad homography, inverted on the CPU, packed into a `mat3x3f` uniform (column-major with vec4-aligned padding). Homography is correct for a flat surface viewed obliquely; bilinear would visibly skew straight lines.

## Test plan

- [x] `npm test` — all 82 tests pass
- [x] `npm run build` — production build succeeds
- [x] `npm run format` — clean

Not verified (no automated harness for the Electron renderer):
- Manual: drop in a Load Movie → Projection Quad → Out chain, drag the corners in the params panel, see the warp follow.
- Manual: Cmd+Shift+F into fullscreen, drag corners on top of the projected image.
- Manual: save and reopen the project — the deserialization fix means corner positions persist (this was the bug that triggered the fix).
- Manual: drag a corner off-screen, click anywhere in the SVG to recover it (closest-wins picks it).

## Known limits (prototype scope)

- **Single window**. In fullscreen the editor disappears; corners can only be adjusted via the projector overlay or by exiting fullscreen first. A two-window setup (editor on laptop, output on projector) needs separate WebGPU contexts and is deferred.
- **Overlay assumes the projection-quad node's output goes straight to `core.out`**. With a Transform/Resize in between, the handle positions will drift from the actual on-screen corners.
- **Corners don't reflow when `outputWidth`/`outputHeight` change** — pixel coords are absolute, not fractional.
- **No keyboard nudging or numeric snapping**; mouse only.
- **Toggling `showUI` requires leaving fullscreen** — a global shortcut would be a natural follow-up.