### PR TITLE
Segment Pose: multi-person masks and correct empty-mask behavior

### DIFF
--- a/src/nodes/ml/segmentPose.js
+++ b/src/nodes/ml/segmentPose.js
@@ -163,7 +163,13 @@ async function drawWorkerResult(result) {
     detectedOut.value = false;
     landmarksOut.value = null;
     maskOut.set(null);
-    imageOut.set(imageIn.value);
+    if (operationIn.value === 'background') {
+      _resultTarget.setSize(width, height);
+      figment.clearRenderTarget(_resultTarget);
+      imageOut.set(_resultTarget);
+    } else {
+      imageOut.set(imageIn.value);
+    }
   }
 }
 

--- a/src/workers/mediapipeWorker.js
+++ b/src/workers/mediapipeWorker.js
@@ -162,14 +162,20 @@ function sanitizeResult(kind, raw, width, height) {
       landmarks: raw.landmarks || [],
     };
   } else if (kind === 'segmentPose') {
-    // Extract a compact Uint8Array mask (single-channel) if available.
+    // Union per-person masks (pixel-wise max) into a single compact Uint8Array.
     let maskBuffer = null;
     if (raw.segmentationMasks && raw.segmentationMasks.length > 0) {
       try {
-        const u8 = raw.segmentationMasks[0].getAsUint8Array();
-        maskBuffer = u8.buffer.slice(0); // copy to detach from wasm memory
+        const first = raw.segmentationMasks[0].getAsUint8Array();
+        const merged = new Uint8Array(first); // copy detaches from WASM memory
+        for (let i = 1; i < raw.segmentationMasks.length; i++) {
+          const next = raw.segmentationMasks[i].getAsUint8Array();
+          for (let p = 0; p < merged.length; p++) {
+            if (next[p] > merged[p]) merged[p] = next[p];
+          }
+        }
+        maskBuffer = merged.buffer;
       } catch (_) {}
-      // Close all masks to free WASM memory
       for (const mask of raw.segmentationMasks) {
         try {
           mask.close();


### PR DESCRIPTION
## Summary
- Worker was extracting only `segmentationMasks[0]` and closing the rest, so Segment Pose silently capped at one person even with `number of poses > 1`. Now merges all per-person masks pixel-wise (max) into one composite — `remove background` keeps every detected person, `remove foreground` removes them all.
- Default `number of poses` stays at `1` so existing graphs pay no extra inference cost.
- Separately, when no person is detected the node used to pass the input through in both modes. That's wrong for `remove background` (no foreground to keep) — now it emits a transparent frame via `figment.clearRenderTarget` in that mode. `remove foreground` is unchanged.

## Test plan
- [x] `npm test` (82/82) and `npm run format`
- [ ] Manual: image with 2+ people, `number of poses=4`, `remove=background` → all people kept; `remove=foreground` → all people removed
- [ ] Manual: single-person image, default settings → identical to before
- [ ] Manual: image with no people, `remove=background` → transparent output; `remove=foreground` → input passes through