### PR TITLE
Fix performance overlay for custom ONNX nodes; clear stale rings on project switch

### DIFF
--- a/src/profiling.js
+++ b/src/profiling.js
@@ -82,6 +82,18 @@ export function clearPerformance() {
   console.log('Performance measurements cleared.');
 }
 
+/**
+ * Reset all overlay/profiling state. Call when the active project changes —
+ * ring buffers are keyed by `node-${type}-${id}`, which is stable inside one
+ * project load but meaningless across loads, so stale entries from the
+ * previous project would otherwise linger in the overlay forever.
+ */
+export function resetProfiling() {
+  ringBuffers.clear();
+  performance.clearMarks();
+  performance.clearMeasures();
+}
+
 // ── Real-time collection via PerformanceObserver ────────────────────
 
 const RING_SIZE = 120; // frames worth of data
@@ -135,7 +147,10 @@ export function startObserver() {
   if (observerStarted) return;
   observerStarted = true;
 
-  const patterns = ['frame', 'render-all-nodes', 'onnx-image:', 'node-'];
+  // 'onnx-' (not 'onnx-image:') so user-defined ONNX nodes that emit measures
+  // under different sub-prefixes (e.g. 'onnx-latent:', 'onnx-detection:') are
+  // captured too. The overlay aggregates phases by suffix across all prefixes.
+  const patterns = ['frame', 'render-all-nodes', 'onnx-', 'node-'];
 
   const observer = new PerformanceObserver((list) => {
     for (const entry of list.getEntries()) {

--- a/src/ui/PerformanceOverlay.jsx
+++ b/src/ui/PerformanceOverlay.jsx
@@ -1,13 +1,40 @@
 import React, { useEffect, useRef } from 'react';
 import { getRollingAvg, getLatest, getTrackedNames, startObserver } from '../profiling';
 
+// A phase row either references a single measure name (`key`) or aggregates
+// all `onnx-*:<onnxSuffix>` rings. Aggregation lets the overlay work for any
+// ONNX node — built-in `onnxImageModel` (prefix `onnx-image:`), custom
+// `onnxLatentModel` (prefix `onnx-latent:`), or future variants — without
+// hard-coding each one. Multiple ONNX nodes active at once sum together.
 const PHASES = [
   { key: 'frame', label: 'Frame', color: '#888' },
   { key: 'render-all-nodes', label: 'Render All', color: '#6cf' },
-  { key: 'onnx-image:preprocess-dispatch', label: 'Pre (GPU→NCHW)', color: '#f90' },
-  { key: 'onnx-image:session-run', label: 'ONNX Inference', color: '#f44' },
-  { key: 'onnx-image:postprocess-dispatch', label: 'Post (NCHW→GPU)', color: '#4c4' },
+  { onnxSuffix: 'preprocess-dispatch', label: 'Pre (GPU→NCHW)', color: '#f90' },
+  { onnxSuffix: 'session-run', label: 'ONNX Inference', color: '#f44' },
+  { onnxSuffix: 'postprocess-dispatch', label: 'Post (NCHW→GPU)', color: '#4c4' },
 ];
+
+function phaseAvg(phase) {
+  if (phase.key) return getRollingAvg(phase.key, 60);
+  let total = 0;
+  for (const name of getTrackedNames()) {
+    if (name.startsWith('onnx-') && name.endsWith(':' + phase.onnxSuffix)) {
+      total += getRollingAvg(name, 60);
+    }
+  }
+  return total;
+}
+
+function phaseLatest(phase) {
+  if (phase.key) return getLatest(phase.key);
+  let total = 0;
+  for (const name of getTrackedNames()) {
+    if (name.startsWith('onnx-') && name.endsWith(':' + phase.onnxSuffix)) {
+      total += getLatest(name);
+    }
+  }
+  return total;
+}
 
 const MAX_NODE_ROWS = 5;
 const WIDTH = 260;
@@ -39,11 +66,13 @@ export default function PerformanceOverlay() {
     }
 
     function draw() {
-      // Collect per-node entries, sort by avg duration descending, take top N
+      // Collect per-node entries, sort by avg duration descending, take top N.
+      // Node measures use the `node-` prefix; ONNX phase measures (which use
+      // `onnx-*:`) are surfaced separately by PHASES, so we don't need to
+      // exclude them here — `startsWith('node-')` is sufficient.
       const allNames = getTrackedNames();
-      const phaseKeys = new Set(PHASES.map((p) => p.key));
       const nodeEntries = allNames
-        .filter((n) => n.startsWith('node-') && !phaseKeys.has(n))
+        .filter((n) => n.startsWith('node-'))
         .map((name) => ({ key: name, label: name.replace('node-', ''), avg: getRollingAvg(name, 60) }))
         .sort((a, b) => b.avg - a.avg)
         .slice(0, MAX_NODE_ROWS);
@@ -69,14 +98,16 @@ export default function PerformanceOverlay() {
 
       // Draw phase rows
       for (let i = 0; i < PHASES.length; i++) {
-        drawRow(ctx, PHASES[i].key, PHASES[i].label, PHASES[i].color, HEADER_H + i * ROW_H, ceil);
+        const phase = PHASES[i];
+        drawRow(ctx, phaseAvg(phase), phaseLatest(phase), phase.label, phase.color, HEADER_H + i * ROW_H, ceil);
       }
 
       // Draw top-N node rows
       if (hasNodes) {
         const nodeStartY = HEADER_H + PHASES.length * ROW_H + SECTION_GAP;
         for (let i = 0; i < nodeEntries.length; i++) {
-          drawRow(ctx, nodeEntries[i].key, nodeEntries[i].label, '#da0', nodeStartY + i * ROW_H, ceil);
+          const entry = nodeEntries[i];
+          drawRow(ctx, entry.avg, getLatest(entry.key), entry.label, '#da0', nodeStartY + i * ROW_H, ceil);
         }
       }
 
@@ -101,10 +132,7 @@ export default function PerformanceOverlay() {
   );
 }
 
-function drawRow(ctx, key, label, color, y, ceil) {
-  const avg = getRollingAvg(key, 60);
-  const latest = getLatest(key);
-
+function drawRow(ctx, avg, latest, label, color, y, ceil) {
   // Bar
   const barW = ceil > 0 ? Math.min((avg / ceil) * BAR_MAX_W, BAR_MAX_W) : 0;
   ctx.fillStyle = color;

--- a/src/ui/store.js
+++ b/src/ui/store.js
@@ -5,6 +5,7 @@ import { Point } from '../g';
 import { upgradeProject } from '../file-format';
 import { PORT_TYPE_IMAGE } from '../model/Port';
 import { findWebGLTypes, submitMigration, startPolling, fetchResult } from '../migration';
+import { resetProfiling } from '../profiling';
 
 // Centralized app UI state using Zustand
 const HISTORY_LIMIT = 50;
@@ -381,6 +382,8 @@ export const useAppStore = create((set, get) => ({
     get().setDirty(false);
     set({ filePath: undefined, tabs: [], activeTabIndex: -1, selection: new Set(), undoStack: [], redoStack: [] });
     window.desktop.stopOscServer();
+    // Ring buffers are keyed by node id; identities don't carry across projects.
+    resetProfiling();
   },
   async newProject() {
     get().closeProject();


### PR DESCRIPTION
## Summary

Two bugs in the performance overlay surfaced when running a project that uses a user-defined ONNX node (`project.oNNXLatentModel`, prefix `onnx-latent:`) instead of the built-in `ml.onnxImageModel` (prefix `onnx-image:`):

1. **ONNX rows showed 0ms during heavy inference.** The `PerformanceObserver` in `profiling.js` only listened for the `onnx-image:` prefix, so `onnx-latent:*` measures were silently dropped. Broadened to `onnx-` and made `PerformanceOverlay.jsx` aggregate phases by suffix (`preprocess-dispatch`, `session-run`, `postprocess-dispatch`) across all `onnx-*:` prefixes. Multiple ONNX nodes now sum; future variants need no overlay change.

2. **Phantom rows from previous projects.** Ring buffers are keyed by `node-${type}-${id}`, but ids are only stable within one project load. Nothing cleared them across loads, so e.g. `image.loadMovie-1` from a previously-opened project kept its avg forever. Added `resetProfiling()` and call it from `closeProject()` — the single hook every project-replacement path (openFile, newProject, migration completion) goes through.

Verified live in the running Electron app: ONNX Inference now reads ~205ms on a StyleGAN2 project, and the per-node list matches the current network exactly.

## Test plan

- [x] `npm run format`
- [x] `npm test` — 82/82 pass
- [x] `npm run build` — clean
- [x] Manual: opened `weight-chaos/stylegan2.fgmt` (uses custom `oNNXLatentModel`) — `ONNX Inference` row shows real ~205ms reading; node list shows only the current network's nodes, no phantoms.
- [ ] CI: confirm test + format jobs go green.