### PR TITLE
Add Smooth node for temporal image smoothing

### DIFF
--- a/src/nodes/image/smooth.js
+++ b/src/nodes/image/smooth.js
@@ -1,0 +1,63 @@
+/**
+ * @name Smooth
+ * @description Temporally smooth an image over frames.
+ * @category image
+ */
+
+const amountIn = node.numberIn('amount', 0.7, { min: 0, max: 1, step: 0.001 });
+const modeIn = node.selectIn('mode', ['average', 'max', 'min'], 'average');
+const clearIn = node.triggerButtonIn('clear');
+
+const MODE_INDEX = { average: 0, max: 1, min: 2 };
+
+let firstFrame = true;
+
+const result = figment.createFeedbackFilter(node, {
+  label: 'smooth',
+  uniforms: { u_amount: 'f32', u_mode: 'u32', u_is_first_frame: 'u32' },
+  wgsl: `
+    @fragment
+    fn fs_main(in: VertexOutput) -> @location(0) vec4f {
+      let prev = textureSample(u_feedback_texture, defaultSampler, in.uv);
+      let curr = textureSample(u_input_texture, defaultSampler, in.uv);
+
+      // First frame: skip the blend so the output starts at the input
+      // instead of fading up from the cleared feedback target.
+      if (u.u_is_first_frame == 1u) {
+        return curr;
+      }
+
+      // Cubic curve puts useful range on the slow end: amount=0 passes
+      // current through, amount=1 freezes. w is the weight of the current frame.
+      let w = pow(1.0 - clamp(u.u_amount, 0.0, 1.0), 3.0);
+
+      var out_rgb: vec3f;
+      switch u.u_mode {
+        case 1u: { out_rgb = max(curr.rgb, prev.rgb * (1.0 - w)); }
+        case 2u: { out_rgb = min(curr.rgb, 1.0 - (1.0 - prev.rgb) * (1.0 - w)); }
+        default: { out_rgb = mix(prev.rgb, curr.rgb, w); }
+      }
+
+      // Alpha always uses the average formula — max/min on alpha has no useful meaning.
+      let out_a = mix(prev.a, curr.a, w);
+      return vec4f(out_rgb, out_a);
+    }
+  `,
+  getUniforms: () => {
+    const isFirst = firstFrame ? 1 : 0;
+    firstFrame = false;
+    return {
+      u_amount: amountIn.value,
+      u_mode: MODE_INDEX[modeIn.value] ?? 0,
+      u_is_first_frame: isFirst,
+    };
+  },
+});
+
+function clear() {
+  result.pp.destroy();
+  result.pp = new figment.PingPongTarget();
+  firstFrame = true;
+}
+node.onReset = clear;
+clearIn.onTrigger = clear;


### PR DESCRIPTION
## Summary

New `image.smooth` node — frame-to-frame EMA over the input. Sibling of Trail, but built for opaque footage (and any source with alpha, since it now smooths the alpha channel correctly).

- **Parameter `amount`** (0–1, default 0.7). 0 = passthrough, 1 = freeze. Cubic mapping `w = (1 - amount)^3` concentrates resolution on the slow end of the slider where the useful range lives.
- **Parameter `mode`** (select): `average` (EMA blur), `max` (bright trails decaying toward black), `min` (dark trails decaying toward white). Dispatched in WGSL via a `u32` uniform + `switch` — one pipeline, mode change is free at runtime, no rebuild.
- **`clear` trigger and `node.onReset`** both rebuild the ping-pong target and re-arm the first-frame guard.
- **First-frame handling** uses an explicit `u_is_first_frame` uniform set from JS. Earlier draft re-used `prev.a < 0.001` as a sentinel, which silently depended on `PingPongTarget` clearing to alpha=0 and the shader writing 1.0 every frame. The uniform decouples that, and frees alpha to be smoothed normally.
- **Alpha**: blended with the average formula in every mode (max/min on alpha has no useful meaning). Opaque inputs stay opaque; transparent inputs pass through.

Uses `figment.createFeedbackFilter` — no changes to `figment.js`, `Node.js`, or sibling nodes.

## Test plan

- [x] `npm run format` clean
- [x] `npm test` (126 tests pass)
- [x] `npm run build` succeeds

Not verified in CI (Electron renderer / WebGPU):

- Manual: webcam → smooth → viewer. `amount=0` is identity; `amount=1` freezes; `amount=0.7` (default) noticeably smooths. **clear** snaps back to current input without fade-from-black.
- Manual: with a moving bright shape on dark, switch `mode` between `average / max / min` and confirm trail polarity.
- Manual: image-with-alpha → smooth → composite — alpha should flow through, not be stomped to 1.

Changelog entry is held back per request and will land in a separate commit.