### PR TITLE
Clamp params panel min width; stop long text from shifting layout

### DIFF
--- a/src/ui/Splitter.jsx
+++ b/src/ui/Splitter.jsx
@@ -10,10 +10,9 @@ export default function Splitter({ className, parentRef, direction }) {
     parent.style.cursor = direction === 'horizontal' ? 'ew-resize' : 'ns-resize';
     const mouseMoveHandler = (e) => {
       if (direction === 'horizontal') {
-        // Calculate params panel width (from splitter to right edge)
-        const paramsWidth = parent.clientWidth - e.clientX;
-        setEditorSplitterWidth(paramsWidth);
-        document.documentElement.style.setProperty(`--${className}`, `${paramsWidth}px`);
+        setEditorSplitterWidth(parent.clientWidth - e.clientX);
+        const clamped = useAppStore.getState().editorSplitterWidth;
+        document.documentElement.style.setProperty(`--${className}`, `${clamped}px`);
       } else {
         const sizePct = ((e.clientY - 40) / parent.clientHeight) * 100;
         document.documentElement.style.setProperty(`--${className}`, `${sizePct}%`);

--- a/src/ui/css/main.css
+++ b/src/ui/css/main.css
@@ -16,6 +16,7 @@
   --gray900: #1a202c;
   --font-mono: ui-monospace, Menlo, Monaco, 'Cascadia Mono', 'Segoe UI Mono', monospace;
   --splitter: 350px;
+  --splitter-min: 350px; /* keep in sync with MIN_PARAMS_WIDTH in store.js */
 }
 
 html,
@@ -59,7 +60,7 @@ img {
 
 main {
   display: grid;
-  grid-template-columns: 1fr 4px var(--splitter);
+  grid-template-columns: 1fr 4px max(var(--splitter), var(--splitter-min));
   height: 100vh;
 }
 
@@ -199,6 +200,8 @@ main {
 .params {
   flex: 1;
   background-color: var(--gray900);
+  min-width: 0;
+  overflow: hidden;
 }
 
 .params__empty {
@@ -242,6 +245,11 @@ main {
   align-items: center;
   gap: 1rem;
   margin-right: 0.5rem;
+}
+
+/* Without this, `whitespace-nowrap` content would expand grid tracks and push the kebab icon off-screen. */
+.params__grid > * {
+  min-width: 0;
 }
 
 .params__port {

--- a/src/ui/store.js
+++ b/src/ui/store.js
@@ -10,6 +10,9 @@ import { resetProfiling } from '../profiling';
 // Centralized app UI state using Zustand
 const HISTORY_LIMIT = 50;
 
+// Below this width the params panel starts clipping its kebab menu icons. Keep in sync with --splitter-min in main.css.
+export const MIN_PARAMS_WIDTH = 350;
+
 const initialLibrary = new Library();
 const initialNetwork = new Network(initialLibrary);
 initialNetwork.parse(getDefaultNetwork());
@@ -206,7 +209,9 @@ export const useAppStore = create((set, get) => ({
     else document.documentElement.classList.remove('hide-cursor');
   },
   setEditorSplitterWidth(width) {
-    set({ editorSplitterWidth: width });
+    const clamped = Math.max(MIN_PARAMS_WIDTH, width);
+    if (get().editorSplitterWidth === clamped) return;
+    set({ editorSplitterWidth: clamped });
   },
 
   // File ops


### PR DESCRIPTION
## Summary

Two related issues in the params panel:

1. **Drag below the design minimum hid UI.** The splitter handler wrote the raw drag value into the CSS var (`--splitter`) and `editorSplitterWidth` with no floor, so users could drag past ~350px and lose kebab-menu icons / field controls.
2. **Long parameter text shifted the layout.** `.params__grid` declares `96px 1fr 16px`, but grid items default to `min-width: auto`. A long `whitespace-nowrap` label or value would expand its track past the declared width and push the right-side kebab icon off-screen.

Fix:
- `MIN_PARAMS_WIDTH = 350` enforced inside `setEditorSplitterWidth` (single source of truth, also guards the App.jsx boot path that reads `paramsEl.offsetWidth`). Added a same-value short-circuit so dragging past the clamp doesn't notify subscribers (`ColorParam`, `ProjectionQuadEditor`) every mousemove.
- CSS belt-and-suspenders: grid track now uses `max(var(--splitter), var(--splitter-min))` so layout stays correct even if some path writes a stale CSS var.
- `.params` gets `min-width: 0` + `overflow: hidden`; `.params__grid > *` gets `min-width: 0` so long content clips/ellipsises within its declared track instead of expanding it.

## Test plan

- [x] `npm run format`
- [x] `npm test` — 82/82 pass
- [x] `npm run build` — clean
- [ ] Manual: open any project, drag the splitter past the left edge of the params panel — width pins at 350px instead of collapsing.
- [ ] Manual: paste a long string into a string parameter — the row clips/ellipsises, the kebab icon stays on the right edge, layout doesn't shift.
- [ ] CI: confirm test + format jobs go green.