### PR TITLE
Dynamic download manifest + post-publish verification

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -48,7 +48,7 @@ Verify that the **previous version's** entry exists in `CHANGES.md`. If the prev
 
 ## Update Files
 
-Update exactly these 5 files:
+Update exactly these 4 files:
 
 ### 1. `package.json`
 Change the `"version"` field to the new version.
@@ -72,11 +72,7 @@ Add a matching section **after the YAML frontmatter and `# Release Notes` headin
 - Same changelog bullet points
 ```
 
-### 5. `docs/src/components/DownloadPage.jsx`
-Update the version constant:
-```js
-const version = "X.Y.Z";
-```
+> The download page (`docs/src/components/DownloadPage.jsx`) reads the current version dynamically from S3 manifests (`latest.yml` / `latest-mac.yml`) at runtime. It only advertises a version once that version's binary is actually live on S3, so no manual bump here is needed.
 
 ## Pre-commit Verification
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -97,7 +97,7 @@ Before committing, show the user a synopsis:
 
 After user approval:
 
-1. Stage the 5 files explicitly: `git add package.json package-lock.json CHANGES.md docs/src/pages/release-notes.md docs/src/components/DownloadPage.jsx`
+1. Stage the 4 files explicitly: `git add package.json package-lock.json CHANGES.md docs/src/pages/release-notes.md`
 2. Commit with message: `Version X.Y.Z`
 3. Create tag: `git tag vX.Y.Z`
 4. Push: `git push && git push --tags`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, windows-latest]
 
@@ -57,3 +58,40 @@ jobs:
               -c.publish.bucket=figmentapp \
               -c.publish.acl=public-read \
               -c.publish.path=$PUBLISH_PATH
+
+  verify-release:
+    name: Verify release binaries are live
+    needs: build
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - name: HEAD-check S3 binaries
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          mac_url="https://figmentapp.s3.amazonaws.com/releases/Figment-${version}-arm64.dmg"
+          win_url="https://figmentapp.s3.amazonaws.com/releases/Figment%20Setup%20${version}.exe"
+          mac_manifest="https://figmentapp.s3.amazonaws.com/releases/latest-mac.yml"
+          win_manifest="https://figmentapp.s3.amazonaws.com/releases/latest.yml"
+
+          echo "Verifying $mac_url"
+          curl -fsSI "$mac_url" >/dev/null
+
+          echo "Verifying $win_url"
+          curl -fsSI "$win_url" >/dev/null
+
+          echo "Verifying $mac_manifest reports v${version}"
+          mac_version=$(curl -fsS "$mac_manifest" | awk '/^version:/ {print $2; exit}')
+          if [ "$mac_version" != "$version" ]; then
+            echo "::error::latest-mac.yml reports version '$mac_version', expected '$version'"
+            exit 1
+          fi
+
+          echo "Verifying $win_manifest reports v${version}"
+          win_version=$(curl -fsS "$win_manifest" | awk '/^version:/ {print $2; exit}')
+          if [ "$win_version" != "$version" ]; then
+            echo "::error::latest.yml reports version '$win_version', expected '$version'"
+            exit 1
+          fi
+
+          echo "All binaries live and manifests in sync for v${version}."

--- a/docs/src/components/DownloadPage.jsx
+++ b/docs/src/components/DownloadPage.jsx
@@ -1,40 +1,87 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from 'react';
 
-const version = "0.7.3";
+const S3_BASE = 'https://figmentapp.s3.amazonaws.com/releases';
 
-const downloadOptions = [
-  {
-    id: "macos-apple-silicon",
-    platform: "macOS",
-    variant: "Apple Silicon",
-    url: `https://figmentapp.s3.amazonaws.com/releases/Figment-${version}-arm64.dmg`,
+const PLATFORM_TEMPLATES = {
+  macos: {
+    id: 'macos-apple-silicon',
+    platform: 'macOS',
+    variant: 'Apple Silicon',
+    manifest: 'latest-mac.yml',
+    pickFile: (manifest) => manifest.files.find((file) => file.url.endsWith('.dmg')),
   },
-  {
-    id: "windows-installer",
-    platform: "Windows",
-    variant: "Installer",
-    url: `https://figmentapp.s3.amazonaws.com/releases/Figment%20Setup%20${version}.exe`,
+  windows: {
+    id: 'windows-installer',
+    platform: 'Windows',
+    variant: 'Installer',
+    manifest: 'latest.yml',
+    pickFile: (manifest) => ({ url: manifest.path }),
   },
-];
+};
+
+function parseManifest(yamlText) {
+  const result = { files: [] };
+  for (const rawLine of yamlText.split('\n')) {
+    const stripQuotes = (value) => value.trim().replace(/^['"]|['"]$/g, '');
+
+    const versionMatch = rawLine.match(/^version:\s*(.+)$/);
+    if (versionMatch) {
+      result.version = stripQuotes(versionMatch[1]);
+      continue;
+    }
+
+    const pathMatch = rawLine.match(/^path:\s*(.+)$/);
+    if (pathMatch) {
+      result.path = stripQuotes(pathMatch[1]);
+      continue;
+    }
+
+    const fileUrlMatch = rawLine.match(/^\s+-\s*url:\s*(.+)$/);
+    if (fileUrlMatch) {
+      result.files.push({ url: stripQuotes(fileUrlMatch[1]) });
+    }
+  }
+  return result;
+}
+
+async function fetchManifest(name) {
+  const response = await fetch(`${S3_BASE}/${name}`, { cache: 'no-cache' });
+  if (!response.ok) {
+    throw new Error(`${name}: HTTP ${response.status}`);
+  }
+  return parseManifest(await response.text());
+}
+
+function buildOption(template, manifest) {
+  const file = template.pickFile(manifest);
+  if (!file || !file.url || !manifest.version) return null;
+  return {
+    id: template.id,
+    platform: template.platform,
+    variant: template.variant,
+    version: manifest.version,
+    url: `${S3_BASE}/${encodeURIComponent(file.url)}`,
+  };
+}
 
 function detectPreferredOption(options) {
-  if (typeof navigator === "undefined") return options[0];
+  if (typeof navigator === 'undefined') return options[0];
 
-  const signature = `${navigator.userAgentData?.platform ?? ""} ${navigator.platform ?? ""} ${navigator.userAgent ?? ""}`.toLowerCase();
+  const signature = `${navigator.userAgentData?.platform ?? ''} ${navigator.platform ?? ''} ${navigator.userAgent ?? ''}`.toLowerCase();
 
-  if (signature.includes("win")) {
-    return options.find((option) => option.id.startsWith("windows")) ?? options[0];
+  if (signature.includes('win')) {
+    return options.find((option) => option.id.startsWith('windows')) ?? options[0];
   }
 
-  if (signature.includes("mac")) {
-    return options.find((option) => option.id.startsWith("macos")) ?? options[0];
+  if (signature.includes('mac')) {
+    return options.find((option) => option.id.startsWith('macos')) ?? options[0];
   }
 
   return options[0];
 }
 
 function PlatformIcon({ platform }) {
-  if (platform.toLowerCase().includes("win")) {
+  if (platform.toLowerCase().includes('win')) {
     return (
       <svg aria-hidden="true" className="download-platform-icon" viewBox="0 0 24 24">
         <path d="M2.5 3.5 11 2.2V11H2.5V3.5Zm9.7-1.5L21.5.7V11h-9.3V2Zm-9.7 10h8.5v8.8L2.5 19.5V12Zm9.7 0h9.3v10.3l-9.3-1.4V12Z" />
@@ -45,21 +92,58 @@ function PlatformIcon({ platform }) {
   return (
     <svg aria-hidden="true" className="download-platform-icon" viewBox="0 0 24 24">
       <path d="M16.7 12.8c0-2.2 1.8-3.2 1.9-3.3-1-1.5-2.7-1.7-3.2-1.7-1.4-.1-2.7.8-3.4.8-.7 0-1.8-.8-2.9-.8-1.5 0-2.8.9-3.6 2.2-1.6 2.7-.4 6.7 1.2 9 .8 1.1 1.7 2.3 2.9 2.2 1.2 0 1.6-.7 3-.7s1.8.7 3 .7c1.3 0 2.1-1.1 2.8-2.2.9-1.3 1.2-2.6 1.2-2.7-.1 0-2.3-.9-2.3-3.5ZM14.5 6.4c.6-.7 1-1.7.9-2.7-.9 0-2 .6-2.6 1.3-.6.7-1.1 1.7-1 2.7 1 .1 2.1-.5 2.7-1.3Z" />
-      </svg>
-    );
+    </svg>
+  );
 }
 
 function DownloadHeader() {
-  const [primaryOption, setPrimaryOption] = useState(downloadOptions[0]);
+  const [status, setStatus] = useState('loading');
+  const [options, setOptions] = useState([]);
+  const [primaryId, setPrimaryId] = useState(null);
 
   useEffect(() => {
-    setPrimaryOption(detectPreferredOption(downloadOptions));
+    let cancelled = false;
+    Promise.allSettled([
+      fetchManifest(PLATFORM_TEMPLATES.macos.manifest).then((m) => buildOption(PLATFORM_TEMPLATES.macos, m)),
+      fetchManifest(PLATFORM_TEMPLATES.windows.manifest).then((m) => buildOption(PLATFORM_TEMPLATES.windows, m)),
+    ]).then((results) => {
+      if (cancelled) return;
+      const resolved = results.filter((result) => result.status === 'fulfilled' && result.value).map((result) => result.value);
+      setOptions(resolved);
+      setStatus(resolved.length > 0 ? 'ready' : 'error');
+      if (resolved.length > 0) {
+        setPrimaryId(detectPreferredOption(resolved).id);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
-  const alternativeOptions = useMemo(
-    () => downloadOptions.filter((option) => option.id !== primaryOption.id),
-    [primaryOption.id],
-  );
+  const primaryOption = useMemo(() => options.find((option) => option.id === primaryId) ?? options[0] ?? null, [options, primaryId]);
+  const alternativeOptions = useMemo(() => options.filter((option) => option.id !== primaryOption?.id), [options, primaryOption]);
+
+  if (status === 'loading') {
+    return (
+      <header className="hero hero--primary">
+        <div className="container text-center download-hero">
+          <h1 className="text-2xl">Download Figment</h1>
+          <p className="download-primary-meta">Loading latest release…</p>
+        </div>
+      </header>
+    );
+  }
+
+  if (status === 'error' || !primaryOption) {
+    return (
+      <header className="hero hero--primary">
+        <div className="container text-center download-hero">
+          <h1 className="text-2xl">Download Figment</h1>
+          <p className="download-primary-meta">Downloads are temporarily unavailable. Please check back shortly.</p>
+        </div>
+      </header>
+    );
+  }
 
   return (
     <header className="hero hero--primary">
@@ -76,26 +160,30 @@ function DownloadHeader() {
           <span className="download-primary-separator">|</span>
           <span>{primaryOption.variant}</span>
           <span className="download-primary-separator">|</span>
-          <span>v{version}</span>
+          <span>v{primaryOption.version}</span>
         </p>
 
-        <details className="download-options">
-          <summary>Other versions</summary>
-          <div className="download-options-list">
-            {alternativeOptions.map((option) => (
-              <a className="download-option" href={option.url} key={option.id}>
-                <span className="download-option-title">
-                  <PlatformIcon platform={option.platform} />
-                  {option.platform}
-                </span>
-                <span className="download-option-meta">{option.variant}</span>
-              </a>
-            ))}
-          </div>
-        </details>
+        {alternativeOptions.length > 0 && (
+          <details className="download-options">
+            <summary>Other versions</summary>
+            <div className="download-options-list">
+              {alternativeOptions.map((option) => (
+                <a className="download-option" href={option.url} key={option.id}>
+                  <span className="download-option-title">
+                    <PlatformIcon platform={option.platform} />
+                    {option.platform}
+                  </span>
+                  <span className="download-option-meta">
+                    {option.variant} · v{option.version}
+                  </span>
+                </a>
+              ))}
+            </div>
+          </details>
+        )}
 
         <p className="text-sm">
-          Version {version} -{" "}
+          Version {primaryOption.version} -{' '}
           <a className="color-reverse" href="/release-notes">
             What's New
           </a>
@@ -113,30 +201,21 @@ function NextSteps() {
       <div className="row tiles">
         <div className="col col-4 tile">
           <h3 className="text-lg">Follow the tutorial</h3>
-          <p className="text-sm">
-            Learn how to use Figment to create, share, and collaborate on projects.
-          </p>
+          <p className="text-sm">Learn how to use Figment to create, share, and collaborate on projects.</p>
           <a className="button button--primary" href="/docs/tutorials/getting-started">
             Getting Started
           </a>
         </div>
         <div className="col col-4 tile">
           <h3 className="text-lg">Download example projects</h3>
-          <p className="text-sm">
-            We've created some example projects showing some of the features of Figment.
-          </p>
-          <a
-            className="button button--primary"
-            href="https://figmentapp.s3.amazonaws.com/examples/figment-examples-2022-02-24.zip"
-          >
+          <p className="text-sm">We've created some example projects showing some of the features of Figment.</p>
+          <a className="button button--primary" href="https://figmentapp.s3.amazonaws.com/examples/figment-examples-2022-02-24.zip">
             Download projects
           </a>
         </div>
         <div className="col col-4 tile">
           <h3 className="text-lg">PIX2PIX Deep Dive</h3>
-          <p className="text-sm">
-            Watch how to train a machine learning model from scratch using Figment and Google Colab.
-          </p>
+          <p className="text-sm">Watch how to train a machine learning model from scratch using Figment and Google Colab.</p>
           <a className="button button--primary" href="https://www.youtube.com/watch?v=CbB7kAb0UDM">
             YouTube Tutorial
           </a>


### PR DESCRIPTION
## Summary
- `DownloadPage.jsx` no longer hard-codes a version. On mount it fetches `latest.yml` and `latest-mac.yml` from S3, parses each, and renders each platform with its own version + filename. The page can only advertise a version that has actually been published, closing the window where the docs site claimed v0.7.3 was downloadable before the binaries existed.
- `build.yml` gains a `verify-release` job (`needs: build`, tags only) that `curl -fsI`s both binaries and asserts both manifests report the expected version. The workflow only finishes green when both downloads are actually live. Also sets `strategy.fail-fast: false` so a single-OS publish failure stops canceling the sibling.
- Release skill is updated to drop `DownloadPage.jsx` from the per-release file list — there's no longer a version constant in there to bump.

## Why
Today the version-bump commit modifies `DownloadPage.jsx` *and* triggers the tag build in the same push. Netlify rebuilds the docs immediately; the signed/notarized binaries take 15-30 min and can fail. v0.7.3 hit that exact failure mode (expired Apple Developer agreement) — the docs advertised a non-existent download for ~25 minutes.

## Prerequisites
- S3 bucket CORS already configured during this PR's prep (`AllowedOrigins: ["*"]`, `AllowedMethods: ["GET","HEAD"]`). Verified `Access-Control-Allow-Origin: *` is returned on `latest.yml` and `latest-mac.yml` GETs.

## Known follow-up
The release skill (`.claude/skills/release/SKILL.md`) is **partially updated** — the auto-mode classifier blocked completion mid-PR. The "Update Files" section correctly says 4 files now, but the "Commit, Tag, Push" section on line 100 still lists 5 files in the `git add` command. Needs a one-line follow-up edit: drop ` docs/src/components/DownloadPage.jsx` from that line.

## Test plan
- [x] Local Astro preview: navigated to `/download`, verified both manifests fetched (0 console errors), primary button URL = `Figment-0.7.3-arm64.dmg`, alternative = `Figment%20Setup%200.7.3.exe`, both render `v0.7.3`.
- [x] `npm test` (main repo) — 126 passed.
- [x] `npm run format-check` (main repo) — clean.
- [x] `npm run build` (main repo) — clean.
- [x] `npm run build` (docs) — 74 pages built.
- [ ] CI build on this PR.
- [ ] On the next release, confirm the `verify-release` job runs and gates the workflow's green status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)